### PR TITLE
Fix panic logging callback

### DIFF
--- a/utils/panic.go
+++ b/utils/panic.go
@@ -23,13 +23,20 @@ func PanicHandler(recoverCallback func(any)) func() {
 	}
 }
 
-// LogPanicCallback returns a callback function, given a context and a recovered
-// error value, that logs the error and a stack trace.
-func LogPanicCallback(ctx sdk.Context, r any) func(any) {
-	return func(a any) {
-		stackTrace := string(debug.Stack())
-		ctx.Logger().Error("recovered panic", "recover_err", r, "recover_type", fmt.Sprintf("%T", r), "stack_trace", stackTrace)
-	}
+// LogPanicCallback returns a callback function that logs the recovered error
+// and its stack trace using the provided context.
+func LogPanicCallback(ctx sdk.Context) func(any) {
+        return func(r any) {
+                stackTrace := string(debug.Stack())
+                if logger := ctx.Logger(); logger != nil {
+                        logger.Error(
+                                "recovered panic",
+                                "recover_err", r,
+                                "recover_type", fmt.Sprintf("%T", r),
+                                "stack_trace", stackTrace,
+                        )
+                }
+        }
 }
 
 func MetricsPanicCallback(err any, ctx sdk.Context, key string) {

--- a/utils/panic_test.go
+++ b/utils/panic_test.go
@@ -1,11 +1,13 @@
 package utils_test
 
 import (
-	"errors"
-	"testing"
+       "errors"
+       "testing"
 
-	"github.com/sei-protocol/sei-chain/utils"
-	"github.com/stretchr/testify/require"
+       log "github.com/tendermint/tendermint/libs/log"
+       sdk "github.com/cosmos/cosmos-sdk/types"
+       "github.com/sei-protocol/sei-chain/utils"
+       "github.com/stretchr/testify/require"
 )
 
 func TestHardFail(t *testing.T) {
@@ -17,4 +19,12 @@ func TestHardFail(t *testing.T) {
 		hardFailer()
 	}
 	require.Panics(t, panicHandlingFn)
+}
+
+func TestLogPanicCallback(t *testing.T) {
+       ctx := sdk.Context{}.WithLogger(log.NewNopLogger())
+       require.NotPanics(t, func() {
+               defer utils.PanicHandler(utils.LogPanicCallback(ctx))()
+               panic("test panic")
+       })
 }

--- a/x/epoch/types/hooks.go
+++ b/x/epoch/types/hooks.go
@@ -38,9 +38,7 @@ func (h MultiEpochHooks) BeforeEpochStart(ctx sdk.Context, epoch Epoch) {
 }
 
 func panicCatchingEpochHook(ctx sdk.Context, hookFn func(sdk.Context, Epoch), epoch Epoch) {
-	defer utils.PanicHandler(func(r any) {
-		utils.LogPanicCallback(ctx, r)
-	})()
+        defer utils.PanicHandler(utils.LogPanicCallback(ctx))()
 
 	// cache the context and only write if no panic (which is caught above)
 	cacheCtx, write := ctx.CacheContext()


### PR DESCRIPTION
## Summary
- ensure LogPanicCallback logs recovered panics and handles missing logger
- call LogPanicCallback directly from epoch hooks
- test panic logging callback

## Testing
- `go test ./utils -run TestLogPanicCallback -count=1 -v`
- `go test ./x/epoch/types -run Test -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_68a56ebfe90083228c9eb8090ff1e4d4