### PR TITLE
feat: add per-IP rate limiting for EVM RPC + harden paginated queries against DoS

### DIFF
--- a/.github/workflows/ghcr-integration-test-cleanup.yml
+++ b/.github/workflows/ghcr-integration-test-cleanup.yml
@@ -1,0 +1,59 @@
+# Prune per-run integration test images from GHCR.
+#
+# integration-test.yml pushes ghcr.io/sei-protocol/sei-chain-integration-test-{localnode,rpcnode}:<run_id>
+# on every workflow run. The shared buildx cache lives on the :cache tag and is never deleted here.
+#
+# Packages:
+#   https://github.com/orgs/sei-protocol/packages/container/sei-chain-integration-test-localnode
+#   https://github.com/orgs/sei-protocol/packages/container/sei-chain-integration-test-rpcnode
+
+name: GHCR integration test cleanup
+
+on:
+  schedule:
+    # Every Sunday, 06:00 UTC
+    - cron: '0 6 * * 0'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Log deletions without applying them
+        type: boolean
+        default: true
+      older_than_days:
+        description: Delete run-id tags older than this many days
+        type: number
+        default: 14
+
+concurrency:
+  group: ghcr-integration-test-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Prune old integration test images
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete stale run-id tags
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OLDER_THAN_DAYS: ${{ inputs.older_than_days || 14 }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+        run: |
+          # For each integration test package, delete versions whose tags are all numeric run-IDs and are older than OLDER_THAN_DAYS.
+          # Numeric-only tag filter naturally preserves the :cache tag and any other non-run-ID tags.
+          cutoff=$(date -u -d "${OLDER_THAN_DAYS} days ago" +%s)
+          for pkg in sei-chain-integration-test-localnode sei-chain-integration-test-rpcnode; do
+            gh api --paginate "orgs/sei-protocol/packages/container/${pkg}/versions" \
+              --jq '.[] | select(.metadata.container.tags | length > 0 and all(test("^[0-9]+$"))) | [.id, .created_at] | @tsv' |
+            while IFS=$'\t' read -r version_id created_at; do
+              created_ts=$(date -u -d "$created_at" +%s)
+              if (( created_ts < cutoff )); then
+                echo "Deleting version ${version_id} of ${pkg} (created: ${created_at})"
+                if [[ "$DRY_RUN" != "true" ]]; then
+                  gh api --method DELETE "orgs/sei-protocol/packages/container/${pkg}/versions/${version_id}"
+                fi
+              fi
+            done
+          done

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -106,6 +106,7 @@ jobs:
     runs-on: ubuntu-large
     timeout-minutes: 30
     env:
+      JOB_TIMEOUT: 28m
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       DAPP_TESTS_MNEMONIC: ${{ secrets.DAPP_TESTS_MNEMONIC }}
@@ -128,9 +129,7 @@ jobs:
           {
             name: "Mint & Staking & Bank Module",
             scripts: [
-              "python3 integration_test/scripts/runner.py integration_test/staking_module/staking_test.yaml",
-              "python3 integration_test/scripts/runner.py integration_test/bank_module/send_funds_test.yaml",
-              "python3 integration_test/scripts/runner.py integration_test/mint_module/mint_test.yaml"
+              "go test -tags yaml_integration -v -timeout $JOB_TIMEOUT ./integration_test/runner/... -run \"TestMintModule|TestStakingModule|TestBankModule\""
             ]
           },
           {

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -22,17 +22,22 @@ defaults:
     shell: bash
 
 jobs:
-  # Build localnode/rpcnode images and seid once; matrix jobs reuse via artifacts.
+  # Build localnode/rpcnode images and seid once; matrix jobs pull the images
+  # from GHCR (tagged with the run id) and download seid as a small artifact.
   prepare-cluster:
     name: Prepare integration test cluster
     runs-on: ubuntu-large
     timeout-minutes: 45
-    # OIDC token required for ECR cache push. Fork PRs cannot obtain it;
-    # aws-login uses continue-on-error so cold builds still succeed.
+    # packages:write required to push images and buildx cache to GHCR. Fork PRs
+    # cannot publish org packages, so integration tests cannot run from forks; a
+    # maintainer must push external contributions to a branch on this repo.
     # cache-to is restricted to push events to avoid cache thrashing on PRs.
     permissions:
-      id-token: write
+      packages: write
       contents: read
+    env:
+      GHCR_LOCALNODE: ghcr.io/sei-protocol/sei-chain-integration-test-localnode
+      GHCR_RPCNODE: ghcr.io/sei-protocol/sei-chain-integration-test-rpcnode
     steps:
       - uses: actions/checkout@v5
       - name: Login to Docker Hub
@@ -43,19 +48,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: AWS Login
-        id: aws-login
-        continue-on-error: true
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::189176372795:role/common/gha
-          role-duration-seconds: 900
-      - name: Login to Amazon ECR
-        id: login-ecr
-        if: steps.aws-login.outcome == 'success'
-        continue-on-error: true
-        uses: aws-actions/amazon-ecr-login@v2
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build localnode image (cached)
@@ -67,8 +65,12 @@ jobs:
           push: false
           load: true
           tags: sei-chain/localnode
-          cache-from: ${{ steps.login-ecr.outputs.registry != '' && format('type=registry,ref={0}/sei/build-cache:integration-localnode', steps.login-ecr.outputs.registry) || '' }}
-          cache-to: ${{ steps.login-ecr.outputs.registry != '' && github.event_name == 'push' && format('type=registry,ref={0}/sei/build-cache:integration-localnode,mode=max', steps.login-ecr.outputs.registry) || '' }}
+          # Run-id label makes each run's image digest unique (config-only
+          # change, layer cache unaffected) so old run tags can be pruned without
+          # touching digests other runs still reference.
+          labels: sei-chain.ci-run-id=${{ github.run_id }}
+          cache-from: type=registry,ref=${{ env.GHCR_LOCALNODE }}:cache
+          cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}:cache,mode=max', env.GHCR_LOCALNODE) || '' }}
       - name: Build rpcnode image (cached)
         uses: docker/build-push-action@v6
         with:
@@ -78,8 +80,9 @@ jobs:
           push: false
           load: true
           tags: sei-chain/rpcnode
-          cache-from: ${{ steps.login-ecr.outputs.registry != '' && format('type=registry,ref={0}/sei/build-cache:integration-rpcnode', steps.login-ecr.outputs.registry) || '' }}
-          cache-to: ${{ steps.login-ecr.outputs.registry != '' && github.event_name == 'push' && format('type=registry,ref={0}/sei/build-cache:integration-rpcnode,mode=max', steps.login-ecr.outputs.registry) || '' }}
+          labels: sei-chain.ci-run-id=${{ github.run_id }}
+          cache-from: type=registry,ref=${{ env.GHCR_RPCNODE }}:cache
+          cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}:cache,mode=max', env.GHCR_RPCNODE) || '' }}
       - uses: actions/setup-go@v6
         with:
           go-version: '1.25.6'
@@ -87,17 +90,20 @@ jobs:
         env:
           DOCKER_PLATFORM: linux/amd64
         run: make build-seid-in-localnode-ci
-      - name: Package CI artifacts
+      # Registry pulls are content-addressed and retried per layer by the docker client
+      - name: Push images to GHCR for test jobs
         run: |
-          tar -czf integration-build.tar.gz build/seid
-          docker save sei-chain/localnode sei-chain/rpcnode | zstd -T0 --fast -o integration-docker-images.tar.zst
+          docker tag sei-chain/localnode "${GHCR_LOCALNODE}:${{ github.run_id }}"
+          docker tag sei-chain/rpcnode "${GHCR_RPCNODE}:${{ github.run_id }}"
+          docker push "${GHCR_LOCALNODE}:${{ github.run_id }}"
+          docker push "${GHCR_RPCNODE}:${{ github.run_id }}"
+      - name: Package CI artifacts
+        run: tar -czf integration-build.tar.gz build/seid
       - name: Upload integration CI artifacts
         uses: actions/upload-artifact@v4
         with:
           name: integration-ci-artifacts
-          path: |
-            integration-build.tar.gz
-            integration-docker-images.tar.zst
+          path: integration-build.tar.gz
           retention-days: 1
 
   integration-tests:
@@ -105,8 +111,13 @@ jobs:
     needs: prepare-cluster
     runs-on: ubuntu-large
     timeout-minutes: 30
+    permissions:
+      packages: read
+      contents: read
     env:
       JOB_TIMEOUT: 28m
+      GHCR_LOCALNODE: ghcr.io/sei-protocol/sei-chain-integration-test-localnode
+      GHCR_RPCNODE: ghcr.io/sei-protocol/sei-chain-integration-test-rpcnode
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       DAPP_TESTS_MNEMONIC: ${{ secrets.DAPP_TESTS_MNEMONIC }}
@@ -433,14 +444,23 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Download integration CI artifacts
         uses: actions/download-artifact@v4
         with:
           name: integration-ci-artifacts
-      - name: Load prebuilt seid and Docker images
+      - name: Load prebuilt seid and pull Docker images
         run: |
           tar -xzf integration-build.tar.gz
-          zstd -d -c integration-docker-images.tar.zst | docker load
+          docker pull "${GHCR_LOCALNODE}:${{ github.run_id }}"
+          docker pull "${GHCR_RPCNODE}:${{ github.run_id }}"
+          docker tag "${GHCR_LOCALNODE}:${{ github.run_id }}" sei-chain/localnode
+          docker tag "${GHCR_RPCNODE}:${{ github.run_id }}" sei-chain/rpcnode
       - name: Start 4 node docker cluster
         run: DOCKER_DETACH=true INVARIANT_CHECK_INTERVAL=10 ${{matrix.test.env}} make docker-cluster-start-ci
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -267,43 +267,6 @@ jobs:
             ],
           },
           {
-            # FlatKV EVM migrate cluster coverage.
-            #
-            # The cluster boots with GIGA_MIGRATE_FROM_MEMIAVL=true so
-            # every validator starts in sc-write-mode = memiavl_only,
-            # i.e. v0 (FlatKV not yet allocated). This is the inverse of
-            # the FlatKV Integration row above (which boots in
-            # test_only_dual_write) and is what makes the migration
-            # script's pre-flip check meaningful: if the matrix env ever
-            # silently lands the cluster in any mode other than
-            # memiavl_only, the script will fail loudly at the pre-flip
-            # grep instead of "succeeding" with a no-op migration.
-            #
-            # Steps:
-            #   1  Deposit an EVM fixture while in v0 so the migration
-            #      has real account+code+storage to drain. The fixture
-            #      writes roughly 4000 storage keys by default so the
-            #      migration spans multiple batches instead of trivially
-            #      completing against an empty or smoke-sized tree.
-            #   2  Coordinated stop -> sed sc-write-mode -> restart on
-            #      all 4 validators, then poll seidb migrate-evm-status
-            #      until every validator reports completion. Cross-
-            #      validator FlatKV digest agreement is asserted at a
-            #      shared post-migration height; any non-determinism in
-            #      the batch copier would surface here as a digest
-            #      mismatch.
-            #   3  Re-run the fixture round-trip check against the
-            #      now-FlatKV-backed EVM state, confirming pre-migration
-            #      data survives the migration intact (read transparency).
-            name: "FlatKV EVM Migrate",
-            env: "GIGA_MIGRATE_FROM_MEMIAVL=true",
-            scripts: [
-              "docker exec sei-node-0 integration_test/contracts/deploy_flatkv_evm_fixture.sh",
-              "./integration_test/contracts/verify_flatkv_evm_migrate.sh",
-              "docker exec sei-node-0 integration_test/contracts/verify_flatkv_evm_store.sh",
-            ],
-          },
-          {
             # Post-migration FlatKV-only state-sync coverage.
             #
             # The cluster boots directly in sc-write-mode = flatkv_only, so

--- a/app/ante/evm_checktx_test.go
+++ b/app/ante/evm_checktx_test.go
@@ -1,0 +1,53 @@
+package ante
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	evmtypes "github.com/sei-protocol/sei-chain/x/evm/types"
+	"github.com/sei-protocol/sei-chain/x/evm/types/ethtx"
+	"github.com/stretchr/testify/require"
+)
+
+type evmStatelessCheckTx struct {
+	msgs []sdk.Msg
+}
+
+func (tx evmStatelessCheckTx) GetMsgs() []sdk.Msg {
+	return tx.msgs
+}
+
+func (tx evmStatelessCheckTx) ValidateBasic() error {
+	return nil
+}
+
+func (tx evmStatelessCheckTx) GetGasEstimate() uint64 {
+	return 0
+}
+
+func TestEvmStatelessChecksRejectsEmptySetCodeAuthList(t *testing.T) {
+	chainID := sdk.NewInt(1)
+	gasTipCap := sdk.NewInt(50)
+	gasFeeCap := sdk.NewInt(100)
+	amount := sdk.NewInt(20)
+	setCodeTx := &ethtx.SetCodeTx{
+		ChainID:   &chainID,
+		Nonce:     1,
+		GasTipCap: &gasTipCap,
+		GasFeeCap: &gasFeeCap,
+		GasLimit:  1000,
+		To:        common.Address{'a'}.Hex(),
+		Amount:    &amount,
+		AuthList:  ethtx.AuthList{},
+		V:         []byte{3},
+		R:         []byte{5},
+		S:         []byte{7},
+	}
+	msg, err := evmtypes.NewMsgEVMTransaction(setCodeTx)
+	require.NoError(t, err)
+
+	err = EvmStatelessChecks(sdk.Context{}, evmStatelessCheckTx{msgs: []sdk.Msg{msg}}, big.NewInt(1))
+	require.ErrorContains(t, err, "auth list cannot be empty")
+}

--- a/app/app.go
+++ b/app/app.go
@@ -1393,10 +1393,11 @@ func (app *App) FinalizeBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock)
 			if app.EvmKeeper.EthReplayConfig.Enabled || app.EvmKeeper.EthBlockTestConfig.Enabled {
 				return &abci.ResponseFinalizeBlock{}, nil
 			}
+			consensusParamUpdates := app.GetConsensusParamsForStateToCommit()
 			cms := app.WriteState()
 			app.LightInvarianceChecks(ctx.Context(), cms, app.lightInvarianceConfig)
 			appHash := app.GetWorkingHash()
-			resp := app.getFinalizeBlockResponse(appHash, events, txRes, endBlockResp)
+			resp := app.getFinalizeBlockResponse(appHash, events, txRes, endBlockResp, consensusParamUpdates)
 			if hasHeadNotifier {
 				headNotifier.Stash(req, &resp)
 			}
@@ -1423,10 +1424,11 @@ func (app *App) FinalizeBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock)
 	if app.EvmKeeper.EthReplayConfig.Enabled || app.EvmKeeper.EthBlockTestConfig.Enabled {
 		return &abci.ResponseFinalizeBlock{}, nil
 	}
+	consensusParamUpdates := app.GetConsensusParamsForStateToCommit()
 	cms := app.WriteState()
 	app.LightInvarianceChecks(ctx.Context(), cms, app.lightInvarianceConfig)
 	appHash := app.GetWorkingHash()
-	resp := app.getFinalizeBlockResponse(appHash, events, txResults, endBlockResp)
+	resp := app.getFinalizeBlockResponse(appHash, events, txResults, endBlockResp, consensusParamUpdates)
 	if hasHeadNotifier {
 		headNotifier.Stash(req, &resp)
 	}
@@ -2442,7 +2444,13 @@ func (app *App) DecodeTransactionsConcurrently(ctx sdk.Context, txs [][]byte) []
 	return typedTxs
 }
 
-func (app *App) getFinalizeBlockResponse(appHash []byte, events []abci.Event, txResults []*abci.ExecTxResult, endBlockResp abci.ResponseEndBlock) abci.ResponseFinalizeBlock {
+func (app *App) getFinalizeBlockResponse(
+	appHash []byte,
+	events []abci.Event,
+	txResults []*abci.ExecTxResult,
+	endBlockResp abci.ResponseEndBlock,
+	consensusParamUpdates *tmproto.ConsensusParams,
+) abci.ResponseFinalizeBlock {
 	if app.EvmKeeper.EthReplayConfig.Enabled || app.EvmKeeper.EthBlockTestConfig.Enabled {
 		return abci.ResponseFinalizeBlock{}
 	}
@@ -2455,27 +2463,74 @@ func (app *App) getFinalizeBlockResponse(appHash []byte, events []abci.Event, tx
 				Power:  v.Power,
 			}
 		}),
-		ConsensusParamUpdates: &tmproto.ConsensusParams{
-			Block: &tmproto.BlockParams{
-				MaxBytes:      endBlockResp.ConsensusParamUpdates.Block.MaxBytes,
-				MaxGas:        endBlockResp.ConsensusParamUpdates.Block.MaxGas,
-				MinTxsInBlock: endBlockResp.ConsensusParamUpdates.Block.MinTxsInBlock,
-				MaxGasWanted:  endBlockResp.ConsensusParamUpdates.Block.MaxGasWanted,
-			},
-			Evidence: &tmproto.EvidenceParams{
-				MaxAgeNumBlocks: endBlockResp.ConsensusParamUpdates.Evidence.MaxAgeNumBlocks,
-				MaxAgeDuration:  endBlockResp.ConsensusParamUpdates.Evidence.MaxAgeDuration,
-				MaxBytes:        endBlockResp.ConsensusParamUpdates.Evidence.MaxBytes,
-			},
-			Validator: &tmproto.ValidatorParams{
-				PubKeyTypes: endBlockResp.ConsensusParamUpdates.Validator.PubKeyTypes,
-			},
-			Version: &tmproto.VersionParams{
-				AppVersion: endBlockResp.ConsensusParamUpdates.Version.AppVersion,
-			},
-		},
-		AppHash: appHash,
+		ConsensusParamUpdates: cloneConsensusParams(consensusParamUpdates),
+		AppHash:               appHash,
 	}
+}
+
+func cloneConsensusParams(params *tmproto.ConsensusParams) *tmproto.ConsensusParams {
+	if params == nil {
+		return nil
+	}
+
+	cp := &tmproto.ConsensusParams{}
+	if params.Block != nil {
+		cp.Block = &tmproto.BlockParams{
+			MaxBytes:      params.Block.MaxBytes,
+			MaxGas:        params.Block.MaxGas,
+			MinTxsInBlock: params.Block.MinTxsInBlock,
+			MaxGasWanted:  params.Block.MaxGasWanted,
+		}
+	}
+	if params.Evidence != nil {
+		cp.Evidence = &tmproto.EvidenceParams{
+			MaxAgeNumBlocks: params.Evidence.MaxAgeNumBlocks,
+			MaxAgeDuration:  params.Evidence.MaxAgeDuration,
+			MaxBytes:        params.Evidence.MaxBytes,
+		}
+	}
+	if params.Validator != nil {
+		cp.Validator = &tmproto.ValidatorParams{
+			PubKeyTypes: append([]string(nil), params.Validator.PubKeyTypes...),
+		}
+	}
+	if params.Version != nil {
+		cp.Version = &tmproto.VersionParams{
+			AppVersion: params.Version.AppVersion,
+		}
+	}
+	if params.Synchrony != nil {
+		cp.Synchrony = &tmproto.SynchronyParams{
+			Precision:    cloneDuration(params.Synchrony.Precision),
+			MessageDelay: cloneDuration(params.Synchrony.MessageDelay),
+		}
+	}
+	if params.Timeout != nil {
+		cp.Timeout = &tmproto.TimeoutParams{
+			Propose:             cloneDuration(params.Timeout.Propose),
+			ProposeDelta:        cloneDuration(params.Timeout.ProposeDelta),
+			Vote:                cloneDuration(params.Timeout.Vote),
+			VoteDelta:           cloneDuration(params.Timeout.VoteDelta),
+			Commit:              cloneDuration(params.Timeout.Commit),
+			BypassCommitTimeout: params.Timeout.BypassCommitTimeout,
+		}
+	}
+	if params.Abci != nil {
+		cp.Abci = &tmproto.ABCIParams{
+			VoteExtensionsEnableHeight: params.Abci.VoteExtensionsEnableHeight,
+			RecheckTx:                  params.Abci.RecheckTx,
+		}
+	}
+
+	return cp
+}
+
+func cloneDuration(duration *time.Duration) *time.Duration {
+	if duration == nil {
+		return nil
+	}
+	cloned := *duration
+	return &cloned
 }
 
 // LoadHeight loads a particular height

--- a/app/consensus_params_test.go
+++ b/app/consensus_params_test.go
@@ -1,0 +1,73 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sei-protocol/sei-chain/sei-tendermint/abci/types"
+	tmproto "github.com/sei-protocol/sei-chain/sei-tendermint/proto/tendermint/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetFinalizeBlockResponsePropagatesFullConsensusParams(t *testing.T) {
+	propose := 300 * time.Millisecond
+	proposeDelta := 50 * time.Millisecond
+	vote := 50 * time.Millisecond
+	voteDelta := 50 * time.Millisecond
+	commit := 200 * time.Millisecond
+	precision := 505 * time.Millisecond
+	messageDelay := 12 * time.Second
+
+	consensusParamUpdates := &tmproto.ConsensusParams{
+		Block: &tmproto.BlockParams{
+			MaxBytes:      22020096,
+			MaxGas:        12500000,
+			MinTxsInBlock: 0,
+			MaxGasWanted:  50000000,
+		},
+		Evidence: &tmproto.EvidenceParams{
+			MaxAgeNumBlocks: 100000,
+			MaxAgeDuration:  48 * time.Hour,
+			MaxBytes:        1048576,
+		},
+		Validator: &tmproto.ValidatorParams{
+			PubKeyTypes: []string{"ed25519"},
+		},
+		Version: &tmproto.VersionParams{
+			AppVersion: 1,
+		},
+		Synchrony: &tmproto.SynchronyParams{
+			Precision:    &precision,
+			MessageDelay: &messageDelay,
+		},
+		Timeout: &tmproto.TimeoutParams{
+			Propose:             &propose,
+			ProposeDelta:        &proposeDelta,
+			Vote:                &vote,
+			VoteDelta:           &voteDelta,
+			Commit:              &commit,
+			BypassCommitTimeout: false,
+		},
+		Abci: &tmproto.ABCIParams{
+			VoteExtensionsEnableHeight: 123,
+			RecheckTx:                  true,
+		},
+	}
+
+	app := &App{}
+	resp := app.getFinalizeBlockResponse(
+		[]byte("hash"),
+		nil,
+		nil,
+		types.ResponseEndBlock{},
+		consensusParamUpdates,
+	)
+
+	require.Equal(t, consensusParamUpdates.Block, resp.ConsensusParamUpdates.Block)
+	require.Equal(t, consensusParamUpdates.Evidence, resp.ConsensusParamUpdates.Evidence)
+	require.Equal(t, consensusParamUpdates.Validator, resp.ConsensusParamUpdates.Validator)
+	require.Equal(t, consensusParamUpdates.Version, resp.ConsensusParamUpdates.Version)
+	require.Equal(t, consensusParamUpdates.Synchrony, resp.ConsensusParamUpdates.Synchrony)
+	require.Equal(t, consensusParamUpdates.Timeout, resp.ConsensusParamUpdates.Timeout)
+	require.Equal(t, consensusParamUpdates.Abci, resp.ConsensusParamUpdates.Abci)
+}

--- a/evmrpc/config/config.go
+++ b/evmrpc/config/config.go
@@ -156,6 +156,13 @@ type Config struct {
 	// SS-pebble. Requires MemiavlOnly write mode; falls back transparently.
 	TraceBakeUseSnapshot    bool  `mapstructure:"trace_bake_use_snapshot"`
 	TraceBakeSnapshotWindow int64 `mapstructure:"trace_bake_snapshot_window"` // recent snapshots to keep (default 64)
+
+	// IPRateLimitRPS is the per-IP sustained request rate in requests/second.
+	// Zero disables per-IP rate limiting (all requests pass through).
+	IPRateLimitRPS float64 `mapstructure:"ip_rate_limit_rps"`
+
+	// IPRateLimitBurst is the maximum per-IP burst size.
+	IPRateLimitBurst int `mapstructure:"ip_rate_limit_burst"`
 }
 
 var DefaultConfig = Config{
@@ -200,6 +207,8 @@ var DefaultConfig = Config{
 	TraceBakeWindowBlocks:   0,
 	TraceBakeUseSnapshot:    false,
 	TraceBakeSnapshotWindow: 64,
+	IPRateLimitRPS:          200,
+	IPRateLimitBurst:        400,
 }
 
 const (
@@ -240,6 +249,8 @@ const (
 	flagTraceBakeWindowBlocks        = "evm.trace_bake_window_blocks"
 	flagTraceBakeUseSnapshot         = "evm.trace_bake_use_snapshot"
 	flagTraceBakeSnapshotWindow      = "evm.trace_bake_snapshot_window"
+	flagIPRateLimitRPS               = "evm.ip_rate_limit_rps"
+	flagIPRateLimitBurst             = "evm.ip_rate_limit_burst"
 )
 
 func ReadConfig(opts servertypes.AppOptions) (Config, error) {
@@ -430,7 +441,16 @@ func ReadConfig(opts servertypes.AppOptions) (Config, error) {
 			return cfg, err
 		}
 	}
-
+	if v := opts.Get(flagIPRateLimitRPS); v != nil {
+		if cfg.IPRateLimitRPS, err = cast.ToFloat64E(v); err != nil {
+			return cfg, err
+		}
+	}
+	if v := opts.Get(flagIPRateLimitBurst); v != nil {
+		if cfg.IPRateLimitBurst, err = cast.ToIntE(v); err != nil {
+			return cfg, err
+		}
+	}
 	return cfg, nil
 }
 
@@ -618,4 +638,12 @@ trace_bake_use_snapshot = {{ .EVM.TraceBakeUseSnapshot }}
 
 # Number of recent memiavl snapshots to retain for trace baking.
 trace_bake_snapshot_window = {{ .EVM.TraceBakeSnapshotWindow }}
+
+# ip_rate_limit_rps is the per-IP sustained request rate in requests/second.
+# Set to 0 to disable per-IP rate limiting (all requests pass through).
+ip_rate_limit_rps = {{ .EVM.IPRateLimitRPS }}
+
+# ip_rate_limit_burst is the maximum per-IP burst above the sustained rate.
+ip_rate_limit_burst = {{ .EVM.IPRateLimitBurst }}
+
 `

--- a/evmrpc/config/config_test.go
+++ b/evmrpc/config/config_test.go
@@ -39,6 +39,8 @@ type opts struct {
 	rpcStatsInterval             interface{}
 	workerPoolSize               interface{}
 	workerQueueSize              interface{}
+	ipRateLimitRPS               interface{}
+	ipRateLimitBurst             interface{}
 }
 
 func (o *opts) Get(k string) interface{} {
@@ -144,6 +146,12 @@ func (o *opts) Get(k string) interface{} {
 		k == "evm.trace_bake_snapshot_window" {
 		return nil
 	}
+	if k == "evm.ip_rate_limit_rps" {
+		return o.ipRateLimitRPS
+	}
+	if k == "evm.ip_rate_limit_burst" {
+		return o.ipRateLimitBurst
+	}
 	panic("unknown key")
 }
 
@@ -180,6 +188,8 @@ func getDefaultOpts() opts {
 		10 * time.Second,
 		32,
 		1000,
+		200.0,
+		400,
 	}
 }
 
@@ -294,6 +304,18 @@ func TestReadConfig(t *testing.T) {
 	badOpts.workerQueueSize = "bad"
 	_, err = config.ReadConfig(&badOpts)
 	require.NotNil(t, err)
+
+	// Test bad types for rate limit config
+	badOpts = goodOpts
+	badOpts.ipRateLimitRPS = "bad"
+	_, err = config.ReadConfig(&badOpts)
+	require.NotNil(t, err)
+
+	badOpts = goodOpts
+	badOpts.ipRateLimitBurst = "bad"
+	_, err = config.ReadConfig(&badOpts)
+	require.NotNil(t, err)
+
 }
 
 // Test worker pool configuration values

--- a/evmrpc/simulate.go
+++ b/evmrpc/simulate.go
@@ -413,12 +413,14 @@ func (b Backend) BlockByNumber(ctx context.Context, bn rpc.BlockNumber) (*ethtyp
 			}
 		}
 		if !shouldTrace {
+			txBytes := tmBlock.Block.Txs[i]
+			txHash := sha256.Sum256(txBytes)
 			metadata = append(metadata, tracersutils.TraceBlockMetadata{
 				ShouldIncludeInTraceResult: false,
 				IdxInEthBlock:              -1,
 				TraceRunnable: func(sd vm.StateDB) {
 					typedStateDB := state.GetDBImpl(sd)
-					_ = b.app.DeliverTx(typedStateDB.Ctx(), abci.RequestDeliverTxV2{}, decoded, sha256.Sum256(tmBlock.Block.Txs[i]))
+					_ = b.app.DeliverTx(typedStateDB.Ctx(), abci.RequestDeliverTxV2{Tx: txBytes}, decoded, txHash)
 				},
 			})
 		}

--- a/evmrpc/simulate_test.go
+++ b/evmrpc/simulate_test.go
@@ -21,7 +21,9 @@ import (
 	"github.com/sei-protocol/sei-chain/app/legacyabci"
 	"github.com/sei-protocol/sei-chain/evmrpc"
 	"github.com/sei-protocol/sei-chain/example/contracts/simplestorage"
+	bam "github.com/sei-protocol/sei-chain/sei-cosmos/baseapp"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client"
+	cosmostestutil "github.com/sei-protocol/sei-chain/sei-cosmos/testutil"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	txtypes "github.com/sei-protocol/sei-chain/sei-cosmos/types/tx"
 	banktypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/bank/types"
@@ -33,9 +35,11 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-tendermint/rpc/coretypes"
 	tmtypes "github.com/sei-protocol/sei-chain/sei-tendermint/types"
 	testkeeper "github.com/sei-protocol/sei-chain/testutil/keeper"
+	"github.com/sei-protocol/sei-chain/x/evm/state"
 	"github.com/sei-protocol/sei-chain/x/evm/types"
 	"github.com/sei-protocol/sei-chain/x/evm/types/ethtx"
 	"github.com/stretchr/testify/require"
+	dbm "github.com/tendermint/tm-db"
 )
 
 func primeReceiptStore(t *testing.T, store receipt.ReceiptStore, latest int64) {
@@ -1003,6 +1007,74 @@ func TestTraceBlockByNumberUsesCompatDecoderForHistoricalCosmosTx(t *testing.T) 
 			require.Contains(t, err.Error(), "exceeds canonical size")
 		})
 	}
+}
+
+// TestBlockByNumberNonTracedTxPassesTxBytes verifies that when BlockByNumber
+// produces a TraceRunnable for a non-EVM (Cosmos) transaction, the runnable
+// calls DeliverTx with req.Tx populated. An empty req.Tx causes ctx.TxBytes()
+// to be nil inside the ante handler, which zeroes out TxSizeCostPerByte gas
+// and diverges from what actually happened on-chain.
+func TestBlockByNumberNonTracedTxPassesTxBytes(t *testing.T) {
+	const blockHeight = int64(42)
+
+	// Build a minimal BaseApp whose sole purpose is to capture ctx.TxBytes()
+	// as seen by the ante handler. BaseApp sets ctx.TxBytes = req.Tx before
+	// invoking the ante handler, so this is the correct interception point.
+	var capturedTxBytes []byte
+	minApp := bam.NewBaseApp("test", dbm.NewMemDB(), TxConfig.TxDecoder(), nil, &cosmostestutil.TestAppOpts{})
+	minApp.SetAnteHandler(func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+		capturedTxBytes = ctx.TxBytes()
+		return ctx, fmt.Errorf("stop") // short-circuit; we only need ante
+	})
+	minApp.Seal()
+
+	testApp := app.Setup(t, false, false, false)
+	_, fromAddr := testkeeper.MockAddressPair()
+	_, toAddr := testkeeper.MockAddressPair()
+	txBuilder := TxConfig.NewTxBuilder()
+	require.NoError(t, txBuilder.SetMsgs(banktypes.NewMsgSend(
+		sdk.AccAddress(fromAddr.Bytes()),
+		sdk.AccAddress(toAddr.Bytes()),
+		sdk.NewCoins(sdk.NewCoin("usei", sdk.NewInt(1))),
+	)))
+	rawTx, err := Encoder(txBuilder.GetTx())
+	require.NoError(t, err)
+
+	tmBlock := &coretypes.ResultBlock{
+		BlockID: tmtypes.BlockID{Hash: bytes.HexBytes(mustHexToBytes("0000000000000000000000000000000000000000000000000000000000000042"))},
+		Block: &tmtypes.Block{
+			Header:     mockBlockHeader(blockHeight),
+			Data:       tmtypes.Data{Txs: []tmtypes.Tx{rawTx}},
+			LastCommit: &tmtypes.Commit{Height: blockHeight},
+		},
+	}
+	ctx := testApp.GetContextForDeliverTx([]byte{}).WithBlockHeight(blockHeight)
+	ctxProvider := func(height int64) sdk.Context {
+		if height == evmrpc.LatestCtxHeight {
+			return ctx
+		}
+		return ctx.WithBlockHeight(height)
+	}
+
+	tmClient := &fixedBlockClient{block: tmBlock}
+	watermarks := evmrpc.NewWatermarkManager(tmClient, ctxProvider, nil, testApp.EvmKeeper.ReceiptStore())
+	backend := evmrpc.NewBackend(
+		ctxProvider, &testApp.EvmKeeper, legacyabci.BeginBlockKeepers{},
+		func(int64) client.TxConfig { return TxConfig }, tmClient, &SConfig,
+		minApp, testApp.TracerAnteHandler,
+		evmrpc.NewBlockCache(3000), &sync.Mutex{}, watermarks,
+	)
+
+	_, metadata, err := backend.BlockByNumber(context.Background(), rpc.BlockNumber(blockHeight))
+	require.NoError(t, err)
+	require.Len(t, metadata, 1)
+	require.NotNil(t, metadata[0].TraceRunnable)
+
+	sdkCtx := testApp.GetContextForDeliverTx([]byte(rawTx)).WithBlockHeight(blockHeight)
+	stateDB := state.NewDBImpl(sdkCtx, &testApp.EvmKeeper, false)
+	metadata[0].TraceRunnable(stateDB)
+
+	require.Equal(t, []byte(rawTx), capturedTxBytes, "DeliverTx must receive the raw tx bytes so ante handler gas charging is faithful to the original execution")
 }
 
 // TestGetTransactionUsesBlockIDHash pins down the GetTransaction → blockHash

--- a/giga/deps/xevm/types/ethtx/semantic_validation.go
+++ b/giga/deps/xevm/types/ethtx/semantic_validation.go
@@ -48,6 +48,9 @@ func validateAccessList(accessList AccessList) error {
 }
 
 func validateAuthList(authList AuthList) error {
+	if len(authList) == 0 {
+		return fmt.Errorf("auth list cannot be empty")
+	}
 	for _, auth := range authList {
 		if auth.ChainID == nil {
 			return fmt.Errorf("auth list chain id cannot be nil")

--- a/go.mod
+++ b/go.mod
@@ -105,6 +105,7 @@ require (
 	google.golang.org/grpc v1.75.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/component-base v0.35.0
 	pgregory.net/rapid v1.2.0
 )
@@ -127,7 +128,6 @@ require (
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/integration_test/bank_module/multi_sig_send_test.yaml
+++ b/integration_test/bank_module/multi_sig_send_test.yaml
@@ -21,6 +21,8 @@
     - cmd: seid tx sign unsigned-tx.json --multisig=$MULTI_SIG_ACC --keyring-backend test --from=wallet2 --output-document=wallet2.json --chain-id sei -b block --fees 1sei
     - cmd: seid tx multisign unsigned-tx.json multisig wallet1.json wallet2.json --chain-id sei --keyring-backend test > signed-tx.json
     - cmd: seid tx broadcast signed-tx.json --chain-id sei -b block -y
+    # cleanup
+    - cmd: rm wallet1.json wallet2.json signed-tx.json unsigned-tx.json
 
     # Check multi-sig balance
     - cmd: seid q bank balances $MULTI_SIG_ACC --output json | jq -r .balances[0].amount

--- a/integration_test/bank_module/simulation_tx.yaml
+++ b/integration_test/bank_module/simulation_tx.yaml
@@ -10,7 +10,7 @@
     # Send funds
     - cmd: printf "12345678\n" | seid tx bank send $ADMIN_ACC $SIMULATION_TEST_ACC 1sei -b block --fees 2000usei --chain-id sei -y
 
-    - cmd: seid tx bank send $ADMIN_ACC $SIMULATION_TEST_ACC 1000sei --from $ADMIN_ACC  --chain-id sei -b block -y --dry-run --keyring-backend test
+    - cmd: seid tx bank send $ADMIN_ACC $SIMULATION_TEST_ACC 1000sei --from $ADMIN_ACC  --chain-id sei -b block -y --dry-run --keyring-backend test 2>&1
       env: GAS_ESIMATE
 
     # Validate that only the 1sei is sent

--- a/integration_test/runner/runner.go
+++ b/integration_test/runner/runner.go
@@ -1,0 +1,359 @@
+// Package runner is a Go-native driver for the YAML integration test suite,
+//
+// It integrates with standard `go test`, so each test case becomes a subtest
+// with proper failure attribution, -run filtering, and -v output.
+//
+// Requires a running Docker cluster. Start one with `make docker-cluster-start`.
+//
+// Run a single module:
+//
+//	go test -tags yaml_integration -v ./integration_test/runner/... -run TestBankModule
+//
+// Run everything:
+//
+//	go test -tags yaml_integration -v ./integration_test/runner/...
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// TestCase mirrors the YAML schema used by the existing test files.
+type TestCase struct {
+	Name      string     `yaml:"name"`
+	Inputs    []Input    `yaml:"inputs"`
+	Verifiers []Verifier `yaml:"verifiers"`
+}
+
+// Input is one command step within a test case.
+type Input struct {
+	Cmd  string `yaml:"cmd"`
+	Env  string `yaml:"env,omitempty"`  // capture trimmed stdout into this name
+	Node string `yaml:"node,omitempty"` // docker container; defaults to Options.DefaultContainer
+}
+
+// Verifier checks the accumulated env map after all inputs have run.
+type Verifier struct {
+	Type   string `yaml:"type"` // "eval" or "regex"
+	Expr   string `yaml:"expr"`
+	Result string `yaml:"result,omitempty"` // env var to match (regex only)
+}
+
+// Options controls how RunFile executes commands.
+type Options struct {
+	// DefaultContainer is the docker container used when an Input has no Node set.
+	DefaultContainer string
+	// ExtraPath is appended to PATH inside docker containers.
+	ExtraPath string
+	// Shell is the shell used to execute commands (e.g. "sh", "bash").
+	// Resolved via PATH at runtime. Defaults to "sh".
+	Shell string
+}
+
+// Option is a functional option for Options.
+type Option func(*Options)
+
+// WithContainer sets the default docker container for inputs that don't specify one.
+func WithContainer(container string) Option {
+	return func(o *Options) { o.DefaultContainer = container }
+}
+
+// WithExtraPath overrides the PATH suffix injected into docker containers.
+func WithExtraPath(path string) Option {
+	return func(o *Options) { o.ExtraPath = path }
+}
+
+// WithShell overrides the shell used to execute commands. Resolved via PATH at runtime.
+func WithShell(shell string) Option {
+	return func(o *Options) { o.Shell = shell }
+}
+
+func newOptions(opts []Option) Options {
+	var o Options
+	//applying default options
+	for _, f := range []Option{WithContainer("sei-node-0"), WithExtraPath("/root/go/bin:/root/.foundry/bin"), WithShell("bash")} {
+		f(&o)
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}
+
+// RunFile reads path as a YAML list of TestCases and runs each as a subtest of t.
+func RunFile(t *testing.T, path string, opts ...Option) {
+	t.Helper()
+	o := newOptions(opts)
+	data, err := os.ReadFile(path) //nolint:gosec
+	require.NoError(t, err, "read %s: %v", path, err)
+	var cases []TestCase
+	require.NoError(t, yaml.Unmarshal(data, &cases), "unmarshal %s: %v", path, err)
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			runCase(t, tc, o)
+		})
+	}
+}
+
+func runCase(t *testing.T, tc TestCase, opts Options) {
+	t.Helper()
+	envMap := make(map[string]string)
+
+	for i, inp := range tc.Inputs {
+		container := inp.Node
+		if container == "" {
+			container = opts.DefaultContainer
+		}
+		out, err := execCmd(t, inp.Cmd, container, envMap, opts)
+		t.Logf("[%d] $ %s\n    => %s", i, inp.Cmd, out)
+		require.NoError(t, err, "input[%d] failed: %v", i, err)
+		if inp.Env != "" {
+			envMap[inp.Env] = out
+		}
+	}
+
+	for _, v := range tc.Verifiers {
+		if err := verify(v, envMap); err != nil {
+			t.Errorf("verifier %s %q: %v", v.Type, v.Expr, err)
+		}
+	}
+}
+
+// execCmd runs cmd in the given docker container (or locally if container is empty),
+// injecting the accumulated envMap. Non-zero exit is logged but not fatal — this
+// matches runner.py behaviour where commands that echo error codes exit 0 from
+// bash but the captured output is the code.
+func execCmd(t *testing.T, cmd, container string, envMap map[string]string, opts Options) (string, error) {
+	t.Helper()
+	var c *exec.Cmd
+
+	if container != "" {
+		// capacity: 1 ("exec") + 2*len(envMap) ("-e" + "k=v" per entry) + 4 (container, "/bin/bash", "-c", cmd)
+		args := make([]string, 1, 1+2*len(envMap)+4)
+		args[0] = "exec"
+		for k, v := range envMap {
+			args = append(args, "-e", k+"="+v)
+		}
+		args = append(args, container, opts.Shell, "-c",
+			"export PATH=$PATH:"+opts.ExtraPath+" && "+cmd)
+		c = exec.Command("docker", args...) //nolint:gosec
+	} else {
+		c = exec.Command(opts.Shell, "-c", cmd) //nolint:gosec
+		c.Env = append(os.Environ(), envMapSlice(envMap)...)
+	}
+
+	out, err := c.Output()
+	stdout := strings.TrimSpace(string(out))
+	if err != nil {
+		var exit *exec.ExitError
+		if errors.As(err, &exit) {
+			t.Logf("    (exit %d) stderr: %s", exit.ExitCode(), strings.TrimSpace(string(exit.Stderr)))
+			return stdout, nil
+		}
+		return stdout, err
+	}
+	return stdout, nil
+}
+
+// envMapSlice converts envMap to a slice of "K=V" strings suitable for exec.Cmd.Env.
+func envMapSlice(envMap map[string]string) []string {
+	s := make([]string, 0, len(envMap))
+	for k, v := range envMap {
+		s = append(s, k+"="+v)
+	}
+	return s
+}
+
+// verify evaluates a single Verifier against the accumulated env map.
+func verify(v Verifier, envMap map[string]string) error {
+	switch v.Type {
+	case "eval":
+		ok, err := evalExpr(v.Expr, envMap)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("false: %s%s", v.Expr, fmtRelevant(v.Expr, envMap))
+		}
+		return nil
+	case "regex":
+		val := envMap[v.Result]
+		ok, err := regexp.MatchString(v.Expr, val)
+		if err != nil {
+			return fmt.Errorf("bad pattern %q: %w", v.Expr, err)
+		}
+		if !ok {
+			return fmt.Errorf("pattern %q did not match %q", v.Expr, val)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown verifier type %q", v.Type)
+	}
+}
+
+// evalExpr evaluates a Python-runner-compatible eval expression.
+// Handles: VAR op literal, VAR op VAR, expr and expr, expr or expr.
+// Operators: ==, !=, >, <, >=, <=.
+func evalExpr(expr string, envMap map[string]string) (bool, error) {
+	if parts := strings.Split(expr, " and "); len(parts) > 1 {
+		for _, p := range parts {
+			ok, err := evalExpr(strings.TrimSpace(p), envMap)
+			if err != nil {
+				return false, err
+			}
+			if !ok {
+				return false, nil
+			}
+		}
+		return true, nil
+	}
+	if parts := strings.Split(expr, " or "); len(parts) > 1 {
+		for _, p := range parts {
+			ok, err := evalExpr(strings.TrimSpace(p), envMap)
+			if err == nil && ok {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	return cmpExpr(strings.TrimSpace(expr), envMap)
+}
+
+// cmpExpr evaluates a single "LHS op RHS" comparison.
+// It tokenizes by whitespace first and substitutes env var names before
+// locating the operator, so arithmetic sub-expressions like EXPECTED_COUNTS + 1
+// are evaluated rather than compared as literal strings.
+func cmpExpr(expr string, envMap map[string]string) (bool, error) {
+	tokens := strings.Fields(expr)
+	for i, t := range tokens {
+		if len(t) >= 2 && t[0] == '"' && t[len(t)-1] == '"' {
+			tokens[i] = t[1 : len(t)-1]
+		} else if v, ok := envMap[t]; ok {
+			tokens[i] = v
+		}
+	}
+	for i, t := range tokens {
+		for _, op := range []string{"!=", ">=", "<=", "==", ">", "<"} {
+			if t == op {
+				lhs, err := evalArith(tokens[:i])
+				if err != nil {
+					return false, err
+				}
+				rhs, err := evalArith(tokens[i+1:])
+				if err != nil {
+					return false, err
+				}
+				return cmpValues(lhs, rhs, op)
+			}
+		}
+	}
+	return false, fmt.Errorf("no operator in %q", expr)
+}
+
+// evalArith evaluates a sequence of tokens as big.Int arithmetic (e.g. ["4", "+", "1"] → "5").
+// Falls back to the raw joined string when the first token is not a valid integer,
+// allowing float and string comparisons to fall through to cmpValues.
+func evalArith(tokens []string) (string, error) {
+	if len(tokens) == 0 {
+		return "", fmt.Errorf("empty side of comparison")
+	}
+	if len(tokens) == 1 {
+		return tokens[0], nil
+	}
+	result := new(big.Int)
+	if _, ok := result.SetString(tokens[0], 10); !ok {
+		return strings.Join(tokens, " "), nil
+	}
+	for i := 1; i+1 < len(tokens); i += 2 {
+		operand := new(big.Int)
+		if _, ok := operand.SetString(tokens[i+1], 10); !ok {
+			return strings.Join(tokens, " "), nil
+		}
+		switch tokens[i] {
+		case "+":
+			result.Add(result, operand)
+		case "-":
+			result.Sub(result, operand)
+		case "*":
+			result.Mul(result, operand)
+		case "/":
+			if operand.Sign() == 0 {
+				return "", fmt.Errorf("division by zero in %v", tokens)
+			}
+			result.Div(result, operand)
+		default:
+			return strings.Join(tokens, " "), nil
+		}
+	}
+	return result.String(), nil
+}
+
+// cmpValues compares a and b with op. Tries big.Int (for large integers without
+// float64 precision loss), then float64, then string.
+func cmpValues(a, b, op string) (bool, error) {
+	a, b = strings.TrimSpace(a), strings.TrimSpace(b)
+
+	ai, bi := new(big.Int), new(big.Int)
+	if _, ok1 := ai.SetString(a, 10); ok1 {
+		if _, ok2 := bi.SetString(b, 10); ok2 {
+			return applyOp(ai.Cmp(bi), op)
+		}
+	}
+
+	fa, errA := strconv.ParseFloat(a, 64)
+	fb, errB := strconv.ParseFloat(b, 64)
+	if errA == nil && errB == nil {
+		c := 0
+		if fa < fb {
+			c = -1
+		} else if fa > fb {
+			c = 1
+		}
+		return applyOp(c, op)
+	}
+
+	return applyOp(strings.Compare(a, b), op)
+}
+
+func applyOp(cmp int, op string) (bool, error) {
+	switch op {
+	case "==":
+		return cmp == 0, nil
+	case "!=":
+		return cmp != 0, nil
+	case ">":
+		return cmp > 0, nil
+	case "<":
+		return cmp < 0, nil
+	case ">=":
+		return cmp >= 0, nil
+	case "<=":
+		return cmp <= 0, nil
+	}
+	return false, fmt.Errorf("unknown operator %q", op)
+}
+
+// fmtRelevant returns a diagnostic string listing env vars referenced in expr.
+func fmtRelevant(expr string, envMap map[string]string) string {
+	var refs []string
+	for k, v := range envMap {
+		if strings.Contains(expr, k) {
+			refs = append(refs, k+"="+v)
+		}
+	}
+	if len(refs) == 0 {
+		return ""
+	}
+	return " [" + strings.Join(refs, ", ") + "]"
+}

--- a/integration_test/runner/runner_test.go
+++ b/integration_test/runner/runner_test.go
@@ -1,0 +1,92 @@
+//go:build yaml_integration
+
+// Package runner_test wires the existing YAML test files into standard `go test`.
+//
+// Requires a running Docker cluster (`make docker-cluster-start`).
+//
+// Run a single module:
+//
+//	go test -tags yaml_integration -v ./integration_test/runner/... -run TestBankModule
+//
+// Run all modules:
+//
+//	go test -tags yaml_integration -v ./integration_test/runner/...
+//
+// Each YAML test case becomes a named subtest, so -run accepts the full path:
+//
+//	-run TestBankModule/Test_sending_funds
+package runner_test
+
+import (
+	"testing"
+
+	"github.com/sei-protocol/sei-chain/integration_test/runner"
+)
+
+func TestStartup(t *testing.T) {
+	runner.RunFile(t, "../startup/startup_test.yaml")
+}
+
+// Tests are declared in the order the CI matrix ran them as Python scripts
+// (go test executes tests in declaration order): staking, then bank, then mint.
+
+func TestStakingModule(t *testing.T) {
+	runner.RunFile(t, "../staking_module/staking_test.yaml")
+}
+
+func TestBankModule(t *testing.T) {
+	runner.RunFile(t, "../bank_module/send_funds_test.yaml")
+	runner.RunFile(t, "../bank_module/multi_sig_send_test.yaml")
+	runner.RunFile(t, "../bank_module/simulation_tx.yaml")
+}
+
+func TestMintModule(t *testing.T) {
+	runner.RunFile(t, "../mint_module/mint_test.yaml")
+}
+
+func TestGovModule(t *testing.T) {
+	runner.RunFile(t, "../gov_module/gov_proposal_test.yaml")
+	runner.RunFile(t, "../gov_module/staking_proposal_test.yaml")
+}
+
+func TestOracleModule(t *testing.T) {
+	runner.RunFile(t, "../oracle_module/verify_penalty_counts.yaml")
+	runner.RunFile(t, "../oracle_module/set_feeder_test.yaml")
+}
+
+func TestDistributionModule(t *testing.T) {
+	runner.RunFile(t, "../distribution_module/community_pool.yaml")
+	runner.RunFile(t, "../distribution_module/rewards.yaml")
+}
+
+func TestTokenFactoryModule(t *testing.T) {
+	runner.RunFile(t, "../tokenfactory_module/create_tokenfactory_test.yaml")
+}
+
+func TestAuthzModule(t *testing.T) {
+	runner.RunFile(t, "../authz_module/send_authorization_test.yaml")
+	runner.RunFile(t, "../authz_module/staking_authorization_test.yaml")
+	runner.RunFile(t, "../authz_module/generic_authorization_test.yaml")
+}
+
+func TestWasmModule(t *testing.T) {
+	runner.RunFile(t, "../wasm_module/timelocked_token_delegation_test.yaml")
+	runner.RunFile(t, "../wasm_module/timelocked_token_admin_test.yaml")
+	runner.RunFile(t, "../wasm_module/timelocked_token_withdraw_test.yaml")
+	runner.RunFile(t, "../wasm_module/timelocked_token_emergency_withdraw_test.yaml")
+}
+
+func TestSeiDB(t *testing.T) {
+	runner.RunFile(t, "../seidb/flatkv_evm_test.yaml")
+	runner.RunFile(t, "../seidb/state_store_test.yaml")
+}
+
+func TestChainOperation(t *testing.T) {
+	runner.RunFile(t, "../chain_operation/snapshot_operation.yaml")
+}
+
+// TestStateSync requires the sei-rpc-node container, which is only present in
+// the CI RPC-node cluster (make run-rpc-node-integration-ci).
+func TestStateSync(t *testing.T) {
+	runner.RunFile(t, "../chain_operation/statesync_operation.yaml")
+}

--- a/ratelimiter/metrics.go
+++ b/ratelimiter/metrics.go
@@ -1,0 +1,27 @@
+package ratelimiter
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+)
+
+var (
+	registryMeter = otel.Meter("ratelimiter")
+
+	registryMetrics = struct {
+		rejectedCounter metric.Int64Counter
+	}{
+		rejectedCounter: must(registryMeter.Int64Counter(
+			"rpc_rate_limit_rejected_total",
+			metric.WithDescription("Total RPC requests rejected by the per-IP rate limiter"),
+			metric.WithUnit("{request}"),
+		)),
+	}
+)
+
+func must[V any](v V, err error) V {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}

--- a/ratelimiter/registry.go
+++ b/ratelimiter/registry.go
@@ -1,0 +1,229 @@
+package ratelimiter
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+)
+
+const (
+	DefaultRPS   = 200.0
+	DefaultBurst = 400
+
+	// lruSize bounds memory to ~8 MB at 50k entries (~160 bytes each).
+	lruSize = 50_000
+	// lruTTL evicts IP entries that have been idle for 1 hour.
+	lruTTL = time.Hour
+)
+
+// DefaultTrustedProxyCIDRs is the full set of RFC-1918 private ranges and loopback.
+// Use it only when every IP in these ranges is controlled infrastructure that you
+// trust not to forge X-Forwarded-For — for example, a k8s cluster where the entire
+// pod network is your own ingress tier. In any other deployment (co-tenanted
+// networks, shared VPCs, partial trust) pass the specific ingress CIDRs instead.
+// Trusting the full RFC-1918 space lets any compromised internal service claim an
+// arbitrary client IP, bypassing per-IP rate limiting.
+var DefaultTrustedProxyCIDRs = []string{
+	"127.0.0.0/8",
+	"::1/128",
+	"10.0.0.0/8",
+	"172.16.0.0/12",
+	"192.168.0.0/16",
+	"fc00::/7",
+}
+
+// Config holds the configuration for a Registry
+type Config struct {
+	// RPS is the sustained request rate allowed per IP in requests/second.
+	// Zero disables per-IP rate limiting (all requests pass).
+	RPS float64
+	// Burst is the maximum number of requests allowed in a single burst.
+	// Zero disables per-IP rate limiting (all requests pass).
+	Burst int
+	// TrustedProxyCIDRs lists CIDRs whose X-Forwarded-For headers are trusted.
+	// Empty means trust no proxy; use RemoteAddr / peer address directly.
+	TrustedProxyCIDRs []string
+}
+
+// DefaultConfig uses no trusted proxies. If your node is behind a reverse proxy or
+// load-balancer, set TrustedProxyCIDRs to the specific ingress CIDRs (or
+// DefaultTrustedProxyCIDRs for a fully-controlled k8s pod network).
+var DefaultConfig = Config{
+	RPS:   DefaultRPS,
+	Burst: DefaultBurst,
+}
+
+// Registry is a per-IP token-bucket rate limiter backed by an expirable LRU.
+// It is safe for concurrent use.
+type Registry struct {
+	cfg            Config
+	trustedProxies []*net.IPNet
+	lru            *expirable.LRU[string, *rate.Limiter]
+	mu             sync.Mutex
+}
+
+// New creates a Registry from cfg. Returns an error if any CIDR in TrustedProxyCIDRs is invalid.
+func New(cfg Config) (*Registry, error) {
+	proxies, err := parseCIDRs(cfg.TrustedProxyCIDRs)
+	if err != nil {
+		return nil, err
+	}
+	return &Registry{
+		cfg:            cfg,
+		trustedProxies: proxies,
+		lru:            expirable.NewLRU[string, *rate.Limiter](lruSize, nil, lruTTL),
+	}, nil
+}
+
+// Allow reports whether the request from ip should be allowed for the given plane.
+// Rejections increment rpc_rate_limit_rejected_total{plane}.
+func (r *Registry) Allow(ctx context.Context, ip, plane string) bool {
+	if r.cfg.RPS <= 0 || r.cfg.Burst <= 0 {
+		return true
+	}
+	if r.getOrCreate(ip).Allow() {
+		return true
+	}
+	registryMetrics.rejectedCounter.Add(
+		ctx,
+		1,
+		metric.WithAttributes(
+			attribute.String("plane", plane),
+		),
+	)
+	return false
+}
+
+// IPFromHTTPRequest extracts the client IP from an HTTP request.
+// If RemoteAddr belongs to a trusted proxy CIDR, the rightmost untrusted X-Forwarded-For
+// entry is used. Walking right-to-left and skipping trusted CIDRs prevents a client from
+// spoofing their IP by pre-setting X-Forwarded-For before the request reaches the proxy.
+func (r *Registry) IPFromHTTPRequest(req *http.Request) string {
+	remoteIP := stripPort(req.RemoteAddr)
+	if r.isTrustedProxy(remoteIP) {
+		if xff := strings.Join(req.Header.Values("X-Forwarded-For"), ", "); xff != "" {
+			if ip := r.rightmostUntrustedIP(xff); ip != "" {
+				return ip
+			}
+		}
+	}
+	return remoteIP
+}
+
+// IPFromGRPCContext extracts the client IP from a gRPC request context.
+// If the transport peer belongs to a trusted proxy CIDR, the rightmost untrusted
+// x-forwarded-for metadata entry is used.
+func (r *Registry) IPFromGRPCContext(ctx context.Context) string {
+	peerIP := grpcPeerIP(ctx)
+	if peerIP != "" && r.isTrustedProxy(peerIP) {
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			if vals := md.Get("x-forwarded-for"); len(vals) > 0 {
+				if ip := r.rightmostUntrustedIP(strings.Join(vals, ", ")); ip != "" {
+					return ip
+				}
+			}
+		}
+	}
+	return peerIP
+}
+
+// rightmostUntrustedIP walks the comma-separated XFF list from right to left and returns
+// the first IP that is not in TrustedProxyCIDRs. This is the real client IP: proxies
+// append their view of the source address, so the rightmost untrusted entry cannot be
+// forged by the client.
+func (r *Registry) rightmostUntrustedIP(xff string) string {
+	parts := strings.Split(xff, ",")
+	for i := len(parts) - 1; i >= 0; i-- {
+		candidate := strings.TrimSpace(parts[i])
+		if net.ParseIP(candidate) == nil {
+			continue
+		}
+		if !r.isTrustedProxy(candidate) {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// getOrCreate returns the existing limiter for ip or creates a fresh one.
+// Add is called on every hit to refresh the TTL, ensuring only truly idle IPs expire.
+// mu serializes the get-then-add so concurrent first requests for the same IP
+// cannot each install a separate limiter.
+func (r *Registry) getOrCreate(ip string) *rate.Limiter {
+	key := bucketKey(ip)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if l, ok := r.lru.Get(key); ok {
+		r.lru.Add(key, l)
+		return l
+	}
+	l := rate.NewLimiter(rate.Limit(r.cfg.RPS), r.cfg.Burst)
+	r.lru.Add(key, l)
+	return l
+}
+
+// bucketKey returns the LRU key for ip.
+// IPv6 addresses are masked to /64: a client rotating within a /64 prefix
+// would otherwise get a fresh bucket per address.
+func bucketKey(ip string) string {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return ip
+	}
+	if v4 := parsed.To4(); v4 != nil {
+		return v4.String()
+	}
+	return parsed.Mask(net.CIDRMask(64, 128)).String()
+}
+
+func (r *Registry) isTrustedProxy(ip string) bool {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	for _, n := range r.trustedProxies {
+		if n.Contains(parsed) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseCIDRs(cidrs []string) ([]*net.IPNet, error) {
+	out := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid CIDR %q: %w", cidr, err)
+		}
+		out = append(out, network)
+	}
+	return out, nil
+}
+
+func stripPort(addr string) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	return host
+}
+
+func grpcPeerIP(ctx context.Context) string {
+	p, ok := peer.FromContext(ctx)
+	if !ok || p.Addr == nil {
+		return ""
+	}
+	return stripPort(p.Addr.String())
+}

--- a/ratelimiter/registry_test.go
+++ b/ratelimiter/registry_test.go
@@ -1,0 +1,294 @@
+package ratelimiter
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+)
+
+// zeroCfg has RPS=0 which disables limiting.
+var zeroCfg = Config{RPS: 0, Burst: 10}
+
+// negCfg has RPS<0 which disables limiting.
+var negCfg = Config{RPS: -1, Burst: 10}
+
+// zeroBurstCfg has Burst=0 which disables limiting.
+var zeroBurstCfg = Config{RPS: 100, Burst: 0}
+
+func cfg(rps float64, burst int, cidrs ...string) Config {
+	return Config{RPS: rps, Burst: burst, TrustedProxyCIDRs: cidrs}
+}
+
+func mustNew(t *testing.T, c Config) *Registry {
+	t.Helper()
+	r, err := New(c)
+	require.NoError(t, err)
+	return r
+}
+
+// --- Allow ---
+
+func TestAllow_ZeroRPSAlwaysPasses(t *testing.T) {
+	r := mustNew(t, zeroCfg)
+	for range 1000 {
+		require.True(t, r.Allow(t.Context(), "1.2.3.4", "evm"))
+	}
+}
+
+func TestAllow_NegativeRPSAlwaysPasses(t *testing.T) {
+	r := mustNew(t, negCfg)
+	for range 1000 {
+		require.True(t, r.Allow(t.Context(), "1.2.3.4", "evm"))
+	}
+}
+
+func TestAllow_ZeroBurstAlwaysPasses(t *testing.T) {
+	r := mustNew(t, zeroBurstCfg)
+	for range 1000 {
+		require.True(t, r.Allow(t.Context(), "1.2.3.4", "evm"))
+	}
+}
+
+func TestAllow_BurstThenReject(t *testing.T) {
+	// burst=3, RPS tiny so no token refill during test
+	r := mustNew(t, cfg(0.001, 3))
+	ip := "10.0.0.1"
+	require.True(t, r.Allow(t.Context(), ip, "evm"), "first request in burst")
+	require.True(t, r.Allow(t.Context(), ip, "evm"), "second request in burst")
+	require.True(t, r.Allow(t.Context(), ip, "evm"), "third request in burst")
+	require.False(t, r.Allow(t.Context(), ip, "evm"), "must be rejected after burst exhausted")
+}
+
+func TestAllow_PerIPIsolation(t *testing.T) {
+	r := mustNew(t, cfg(0.001, 1))
+	require.True(t, r.Allow(t.Context(), "1.1.1.1", "evm"))
+	require.False(t, r.Allow(t.Context(), "1.1.1.1", "evm"), "1.1.1.1 exhausted")
+	// Different IP has its own independent bucket.
+	require.True(t, r.Allow(t.Context(), "2.2.2.2", "evm"), "2.2.2.2 should still pass")
+}
+
+func TestAllow_IPv6_SamePrefixSharesBucket(t *testing.T) {
+	r := mustNew(t, cfg(0.001, 1))
+	require.True(t, r.Allow(t.Context(), "2001:db8::1", "evm"), "first address in /64 passes")
+	require.False(t, r.Allow(t.Context(), "2001:db8::2", "evm"), "different address in same /64 rejected")
+}
+
+func TestAllow_IPv6_DifferentPrefixOwnBucket(t *testing.T) {
+	r := mustNew(t, cfg(0.001, 1))
+	require.True(t, r.Allow(t.Context(), "2001:db8:0:1::1", "evm"))
+	require.True(t, r.Allow(t.Context(), "2001:db8:0:2::1", "evm"), "different /64 has its own bucket")
+}
+
+// --- IPFromHTTPRequest ---
+
+func TestIPFromHTTPRequest_DirectConnection(t *testing.T) {
+	r := mustNew(t, cfg(100, 200)) // no trusted proxies
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.5:44321"
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	// RemoteAddr is not in trusted CIDRs, so XFF should be ignored.
+	require.Equal(t, "203.0.113.5", r.IPFromHTTPRequest(req))
+}
+
+func TestIPFromHTTPRequest_TrustedProxy_XFF(t *testing.T) {
+	r := mustNew(t, cfg(100, 200, "10.0.0.0/8"))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:12345"
+	// Proxy appended 203.0.113.5 (real client) on the right; rightmost untrusted wins.
+	req.Header.Set("X-Forwarded-For", "203.0.113.5, 10.0.0.1")
+	require.Equal(t, "203.0.113.5", r.IPFromHTTPRequest(req))
+}
+
+func TestIPFromHTTPRequest_TrustedProxy_SpoofedXFF(t *testing.T) {
+	r := mustNew(t, cfg(100, 200, "10.0.0.0/8"))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:12345"
+	// Client pre-set a spoofed IP; proxy appended the real client IP on the right.
+	// Must use rightmost untrusted (203.0.113.5), not the spoofed leftmost (1.2.3.4).
+	req.Header.Set("X-Forwarded-For", "1.2.3.4, 203.0.113.5")
+	require.Equal(t, "203.0.113.5", r.IPFromHTTPRequest(req))
+}
+
+func TestIPFromHTTPRequest_TrustedProxy_NoXFF(t *testing.T) {
+	r := mustNew(t, cfg(100, 200, "10.0.0.0/8"))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:12345"
+	// No XFF header: fall back to RemoteAddr.
+	require.Equal(t, "10.0.0.1", r.IPFromHTTPRequest(req))
+}
+
+func TestIPFromHTTPRequest_UntrustedProxy_IgnoresXFF(t *testing.T) {
+	// Only loopback is trusted.
+	r := mustNew(t, cfg(100, 200, "127.0.0.0/8"))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.1:9999"
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	require.Equal(t, "203.0.113.1", r.IPFromHTTPRequest(req))
+}
+
+func TestIPFromHTTPRequest_SingleXFFEntry(t *testing.T) {
+	r := mustNew(t, cfg(100, 200, "127.0.0.0/8"))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "127.0.0.1:8080"
+	req.Header.Set("X-Forwarded-For", "  203.0.113.5  ")
+	require.Equal(t, "203.0.113.5", r.IPFromHTTPRequest(req))
+}
+
+func TestIPFromHTTPRequest_MultipleXFFHeaders_SpoofPrevented(t *testing.T) {
+	r := mustNew(t, cfg(100, 200, "10.0.0.0/8"))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:12345"
+	// Client pre-sets a spoofed IP as the first XFF header line.
+	// Proxy adds the real client IP as a separate header line (not appended to the existing one).
+	req.Header.Add("X-Forwarded-For", "spoofed-ip-ignored")
+	req.Header.Add("X-Forwarded-For", "203.0.113.5")
+	// Must use rightmost untrusted across all header lines, not just the first.
+	require.Equal(t, "203.0.113.5", r.IPFromHTTPRequest(req))
+}
+
+// --- IPFromGRPCContext ---
+
+func grpcCtx(peerAddr string, xff ...string) context.Context {
+	ctx := context.Background()
+	ctx = peer.NewContext(ctx, &peer.Peer{
+		Addr: mockAddr(peerAddr),
+	})
+	if len(xff) > 0 {
+		md := metadata.MD{"x-forwarded-for": xff}
+		ctx = metadata.NewIncomingContext(ctx, md)
+	}
+	return ctx
+}
+
+type mockAddr string
+
+func (a mockAddr) Network() string { return "tcp" }
+func (a mockAddr) String() string  { return string(a) }
+
+func TestIPFromGRPCContext_DirectPeer(t *testing.T) {
+	r := mustNew(t, cfg(100, 200)) // no trusted proxies
+	ctx := grpcCtx("203.0.113.5:9000", "1.2.3.4")
+	// Peer is not trusted, XFF must be ignored.
+	require.Equal(t, "203.0.113.5", r.IPFromGRPCContext(ctx))
+}
+
+func TestIPFromGRPCContext_TrustedPeer_XFF(t *testing.T) {
+	r := mustNew(t, cfg(100, 200, "10.0.0.0/8"))
+	// Proxy appended 203.0.113.5 (real client) on the right; rightmost untrusted wins.
+	ctx := grpcCtx("10.0.0.2:9000", "203.0.113.5, 10.0.0.2")
+	require.Equal(t, "203.0.113.5", r.IPFromGRPCContext(ctx))
+}
+
+func TestIPFromGRPCContext_TrustedPeer_SpoofedXFF(t *testing.T) {
+	r := mustNew(t, cfg(100, 200, "10.0.0.0/8"))
+	// Client pre-set a spoofed IP; proxy appended the real client IP on the right.
+	ctx := grpcCtx("10.0.0.2:9000", "1.2.3.4, 203.0.113.5")
+	require.Equal(t, "203.0.113.5", r.IPFromGRPCContext(ctx))
+}
+
+func TestIPFromGRPCContext_MultipleXFFValues_SpoofPrevented(t *testing.T) {
+	r := mustNew(t, cfg(100, 200, "10.0.0.0/8"))
+	// Client pre-sets a spoofed IP as the first metadata value; proxy appends real IP as a second value.
+	ctx := grpcCtx("10.0.0.2:9000", "spoofed-ip-ignored", "203.0.113.5")
+	require.Equal(t, "203.0.113.5", r.IPFromGRPCContext(ctx))
+}
+
+func TestIPFromGRPCContext_TrustedPeer_NoMetadata(t *testing.T) {
+	r := mustNew(t, cfg(100, 200, "10.0.0.0/8"))
+	ctx := grpcCtx("10.0.0.2:9000")
+	require.Equal(t, "10.0.0.2", r.IPFromGRPCContext(ctx))
+}
+
+func TestIPFromGRPCContext_NoPeer(t *testing.T) {
+	r := mustNew(t, cfg(100, 200, "10.0.0.0/8"))
+	require.Equal(t, "", r.IPFromGRPCContext(t.Context()))
+}
+
+// --- isTrustedProxy / parseCIDRs ---
+
+func TestIsTrustedProxy_DefaultConfig_NoProxies(t *testing.T) {
+	r := mustNew(t, DefaultConfig)
+	// DefaultConfig has no trusted proxies; every IP is untrusted.
+	for _, ip := range []string{"127.0.0.1", "::1", "10.1.2.3", "172.16.0.1", "192.168.1.1"} {
+		require.False(t, r.isTrustedProxy(ip), "ip=%s", ip)
+	}
+}
+
+func TestIsTrustedProxy_DefaultTrustedProxyCIDRs(t *testing.T) {
+	r := mustNew(t, Config{RPS: 100, Burst: 10, TrustedProxyCIDRs: DefaultTrustedProxyCIDRs})
+	cases := []struct {
+		ip      string
+		trusted bool
+	}{
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"10.1.2.3", true},
+		{"172.16.0.1", true},
+		{"192.168.1.1", true},
+		{"203.0.113.1", false},
+		{"8.8.8.8", false},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.trusted, r.isTrustedProxy(tc.ip), "ip=%s", tc.ip)
+	}
+}
+
+func TestParseCIDRs_ReturnsErrorOnInvalid(t *testing.T) {
+	_, err := parseCIDRs([]string{"10.0.0.0/8", "not-a-cidr", "192.168.0.0/16"})
+	require.ErrorContains(t, err, "not-a-cidr")
+}
+
+func TestParseCIDRs_Empty(t *testing.T) {
+	nets, err := parseCIDRs(nil)
+	require.NoError(t, err)
+	require.Empty(t, nets)
+}
+
+// --- helpers ---
+
+func TestBucketKey(t *testing.T) {
+	// IPv4: canonical dotted form
+	require.Equal(t, "1.2.3.4", bucketKey("1.2.3.4"))
+	// IPv4-mapped IPv6: canonicalized to dotted form so both forms share one bucket
+	require.Equal(t, "1.2.3.4", bucketKey("::ffff:1.2.3.4"))
+	// IPv6: masked to /64
+	require.Equal(t, "2001:db8::", bucketKey("2001:db8::1"))
+	require.Equal(t, "2001:db8::", bucketKey("2001:db8::ffff"))
+	require.Equal(t, "2001:db8:1:2::", bucketKey("2001:db8:1:2:3:4:5:6"))
+	// Unparseable: passed through unchanged
+	require.Equal(t, "not-an-ip", bucketKey("not-an-ip"))
+}
+
+func TestStripPort(t *testing.T) {
+	require.Equal(t, "1.2.3.4", stripPort("1.2.3.4:8080"))
+	require.Equal(t, "::1", stripPort("[::1]:9090"))
+	require.Equal(t, "1.2.3.4", stripPort("1.2.3.4"))
+}
+
+func TestRightmostUntrustedIP(t *testing.T) {
+	r := mustNew(t, cfg(100, 200, "10.0.0.0/8", "127.0.0.0/8"))
+	require.Equal(t, "203.0.113.5", r.rightmostUntrustedIP("203.0.113.5"))
+	require.Equal(t, "203.0.113.5", r.rightmostUntrustedIP("1.2.3.4, 203.0.113.5"))
+	require.Equal(t, "203.0.113.5", r.rightmostUntrustedIP("1.2.3.4, 203.0.113.5, 10.0.0.1"))
+	require.Equal(t, "203.0.113.5", r.rightmostUntrustedIP("  203.0.113.5  "))        // whitespace stripped
+	require.Equal(t, "", r.rightmostUntrustedIP("10.0.0.1, 127.0.0.1"))               // all trusted → empty
+	require.Equal(t, "", r.rightmostUntrustedIP("not-an-ip"))                         // non-IP skipped
+	require.Equal(t, "", r.rightmostUntrustedIP("not-an-ip, 10.0.0.1"))               // non-IP + trusted → empty, falls back to RemoteAddr
+	require.Equal(t, "203.0.113.5", r.rightmostUntrustedIP("not-an-ip, 203.0.113.5")) // non-IP skipped, valid untrusted returned
+}
+
+// --- New validates TrustedProxyCIDRs ---
+
+func TestNew_InvalidCIDR_ReturnsError(t *testing.T) {
+	_, err := New(Config{
+		RPS:               100,
+		Burst:             10,
+		TrustedProxyCIDRs: []string{"bad", "10.0.0.0/8"},
+	})
+	require.ErrorContains(t, err, "bad")
+}

--- a/scripts/state_sync.sh
+++ b/scripts/state_sync.sh
@@ -13,8 +13,9 @@ echo
 # Create a backup directory for keys
 mkdir -p $HOME/key_backup
 
-# Backup the validator key and state files
+# Backup the validator key, node key, and state files
 cp $HOME/.sei/config/priv_validator_key.json $HOME/key_backup
+cp $HOME/.sei/config/node_key.json $HOME/key_backup
 cp $HOME/.sei/data/priv_validator_state.json $HOME/key_backup
 
 # Create a backup directory for the entire .sei configuration
@@ -28,10 +29,11 @@ mv $HOME/.sei/wasm $HOME/.sei_backup
 # Remove the data and wasm folder
 cd $HOME/.sei && ls | grep -xv "cosmovisor" | xargs rm -rf
 
-# Restore the validator key and state files from the backup
+# Restore the validator key, node key, and state files from the backup
 mkdir -p $HOME/.sei/config
 mkdir -p $HOME/.sei/data
 cp $HOME/key_backup/priv_validator_key.json $HOME/.sei/config/
+cp $HOME/key_backup/node_key.json $HOME/.sei/config/
 cp $HOME/key_backup/priv_validator_state.json $HOME/.sei/data/
 
 # Set up /tmp as a 12G RAM disk to allow for more than 400 state sync chunks

--- a/sei-cosmos/baseapp/baseapp.go
+++ b/sei-cosmos/baseapp/baseapp.go
@@ -697,6 +697,13 @@ func (app *BaseApp) GetConsensusParams(ctx sdk.Context) *tmproto.ConsensusParams
 	return cp
 }
 
+func (app *BaseApp) GetConsensusParamsForStateToCommit() *tmproto.ConsensusParams {
+	if app.stateToCommit == nil {
+		return nil
+	}
+	return app.GetConsensusParams(app.stateToCommit.Context())
+}
+
 // AddRunTxRecoveryHandler adds custom app.runTx method panic handlers.
 func (app *BaseApp) AddRunTxRecoveryHandler(handlers ...RecoveryHandler) {
 	for _, h := range handlers {

--- a/sei-cosmos/storev2/rootmulti/store.go
+++ b/sei-cosmos/storev2/rootmulti/store.go
@@ -398,11 +398,15 @@ func (rs *Store) CacheMultiStoreFromCommitter(snap sctypes.Committer) (types.Cac
 
 // GetStore Implements interface MultiStore
 func (rs *Store) GetStore(key types.StoreKey) types.Store {
+	rs.mtx.RLock()
+	defer rs.mtx.RUnlock()
 	return rs.ckvStores[key]
 }
 
 // GetKVStore Implements interface MultiStore
 func (rs *Store) GetKVStore(key types.StoreKey) types.KVStore {
+	rs.mtx.RLock()
+	defer rs.mtx.RUnlock()
 	return rs.ckvStores[key]
 }
 
@@ -453,6 +457,8 @@ func (rs *Store) GetCommitStore(key types.StoreKey) types.CommitStore {
 
 // GetCommitKVStore Implements interface CommitMultiStore
 func (rs *Store) GetCommitKVStore(key types.StoreKey) types.CommitKVStore {
+	rs.mtx.RLock()
+	defer rs.mtx.RUnlock()
 	return rs.ckvStores[key]
 }
 

--- a/sei-cosmos/storev2/rootmulti/store_test.go
+++ b/sei-cosmos/storev2/rootmulti/store_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sei-protocol/sei-chain/sei-cosmos/store/mem"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/types"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/storev2/state"
 	"github.com/sei-protocol/sei-chain/sei-db/config"
@@ -14,6 +15,35 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 )
+
+func TestGetCommitKVStore_ReaderRespectsWriteLock(t *testing.T) {
+	store := &Store{
+		storeKeys: map[string]types.StoreKey{},
+		ckvStores: map[types.StoreKey]types.CommitKVStore{},
+	}
+	key := types.NewKVStoreKey("bank")
+	store.storeKeys[key.Name()] = key
+	store.ckvStores[key] = mem.NewStore()
+
+	store.mtx.Lock()
+
+	readDone := make(chan types.CommitKVStore, 1)
+	go func() {
+		readDone <- store.GetCommitKVStore(key) //GetCommitKVStore is blocked until store.mtx is unlocked
+	}()
+
+	select {
+	case <-readDone:
+		t.Fatal("GetCommitKVStore returned while write lock held — RLock missing")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	newVal := mem.NewStore()
+	store.ckvStores = map[types.StoreKey]types.CommitKVStore{key: newVal}
+	store.mtx.Unlock()
+
+	require.Same(t, newVal, <-readDone)
+}
 
 func TestLastCommitID(t *testing.T) {
 	store := NewStore(t.TempDir(), config.DefaultStateCommitConfig(), config.StateStoreConfig{}, []string{})

--- a/sei-cosmos/types/query/filtered_pagination.go
+++ b/sei-cosmos/types/query/filtered_pagination.go
@@ -5,16 +5,17 @@ import (
 
 	"github.com/sei-protocol/sei-chain/sei-cosmos/codec"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // FilteredPaginate does pagination of all the results in the PrefixStore based on the
-// provided PageRequest. onResult should be used to do actual unmarshaling and filter the results.
-// If key is provided, the pagination uses the optimized querying.
-// If offset is used, the pagination uses lazy filtering i.e., searches through all the records.
-// The accumulate parameter represents if the response is valid based on the offset given.
-// It will be false for the results (filtered) < offset  and true for `offset > accumulate <= end`.
-// When accumulate is set to true the current result should be appended to the result set returned
-// to the client.
+// provided PageRequest. onResult does the unmarshaling and filtering.
+// Key-based pagination is optimized; offset-based pagination lazily walks all records.
+//
+// Iteration is capped at MaxScanLimit entries to prevent unbounded store walks. Use key-based
+// pagination for reliable traversal of sparse datasets, as the nextKey could be nil when the
+// page is full and the scan limit is reached.
 func FilteredPaginate(
 	prefixStore types.KVStore,
 	pageRequest *PageRequest,
@@ -36,11 +37,16 @@ func FilteredPaginate(
 		return nil, fmt.Errorf("invalid request, either offset or key is expected, got both")
 	}
 
+	if err := VerifyPaginationOffset(offset); err != nil {
+		return nil, err
+	}
+
 	if limit == 0 {
 		limit = DefaultLimit
+	}
 
-		// count total results when the limit is zero/not supplied
-		countTotal = true
+	if err := VerifyPaginationLimit(limit); err != nil {
+		return nil, err
 	}
 
 	if len(key) != 0 {
@@ -48,14 +54,20 @@ func FilteredPaginate(
 		defer func() { _ = iterator.Close() }()
 
 		var (
-			numHits uint64
-			nextKey []byte
+			numHits   uint64
+			nextKey   []byte
+			totalIter uint64
 		)
 
 		for ; iterator.Valid(); iterator.Next() {
+			totalIter++
 			if numHits == limit {
 				nextKey = iterator.Key()
 				break
+			}
+			if totalIter > MaxScanLimit {
+				return nil, status.Errorf(codes.InvalidArgument,
+					"scanned more than %d entries without filling the page; use a more specific key prefix or reduce limit", MaxScanLimit)
 			}
 
 			if iterator.Error() != nil {
@@ -83,11 +95,30 @@ func FilteredPaginate(
 	end := offset + limit
 
 	var (
-		numHits uint64
-		nextKey []byte
+		numHits          uint64
+		nextKey          []byte
+		totalIter        uint64
+		pageCompleteIter uint64
 	)
 
 	for ; iterator.Valid(); iterator.Next() {
+		totalIter++
+		// Phase 1: page not yet complete — cap raw iterations to prevent full-store
+		// walks when the filter produces too few hits to fill the page.
+		if numHits < end && totalIter > offset+MaxScanLimit {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"scanned more than %d entries without filling the page; use key-based pagination instead", MaxScanLimit)
+		}
+		// Phase 2: page complete — cap how far past the page we scan for nextKey/count_total.
+		if pageCompleteIter > MaxScanLimit {
+			if !countTotal {
+				// Page is already assembled; no next hit found within scan window → no next page.
+				break
+			}
+			return nil, status.Errorf(codes.InvalidArgument,
+				"scanned more than %d entries past the end of the page; use key-based pagination instead", MaxScanLimit)
+		}
+
 		if iterator.Error() != nil {
 			return nil, iterator.Error()
 		}
@@ -100,6 +131,10 @@ func FilteredPaginate(
 
 		if hit {
 			numHits++
+		}
+
+		if numHits >= end {
+			pageCompleteIter++
 		}
 
 		if numHits == end+1 {
@@ -127,6 +162,8 @@ func FilteredPaginate(
 // If offset is used, the pagination uses lazy filtering i.e., searches through all the records.
 // The resulting slice (of type F) can be of a different type than the one being iterated through
 // (type T), so it's possible to do any necessary transformation inside the onResult function.
+//
+// Scan limits: same semantics as FilteredPaginate — see its documentation for details.
 func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 	cdc codec.BinaryCodec,
 	prefixStore types.KVStore,
@@ -150,11 +187,16 @@ func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 		return results, nil, fmt.Errorf("invalid request, either offset or key is expected, got both")
 	}
 
+	if err := VerifyPaginationOffset(offset); err != nil {
+		return results, nil, err
+	}
+
 	if limit == 0 {
 		limit = DefaultLimit
+	}
 
-		// count total results when the limit is zero/not supplied
-		countTotal = true
+	if err := VerifyPaginationLimit(limit); err != nil {
+		return results, nil, err
 	}
 
 	if len(key) != 0 {
@@ -162,14 +204,20 @@ func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 		defer func() { _ = iterator.Close() }()
 
 		var (
-			numHits uint64
-			nextKey []byte
+			numHits   uint64
+			nextKey   []byte
+			totalIter uint64
 		)
 
 		for ; iterator.Valid(); iterator.Next() {
+			totalIter++
 			if numHits == limit {
 				nextKey = iterator.Key()
 				break
+			}
+			if totalIter > MaxScanLimit {
+				return nil, nil, status.Errorf(codes.InvalidArgument,
+					"scanned more than %d entries without filling the page; use a more specific key prefix or reduce limit", MaxScanLimit)
 			}
 
 			if iterator.Error() != nil {
@@ -205,11 +253,30 @@ func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 	end := offset + limit
 
 	var (
-		numHits uint64
-		nextKey []byte
+		numHits          uint64
+		nextKey          []byte
+		totalIter        uint64
+		pageCompleteIter uint64
 	)
 
 	for ; iterator.Valid(); iterator.Next() {
+		totalIter++
+		// Phase 1: page not yet complete — cap raw iterations to prevent full-store
+		// walks when the filter produces too few hits to fill the page.
+		if numHits < end && totalIter > offset+MaxScanLimit {
+			return nil, nil, status.Errorf(codes.InvalidArgument,
+				"scanned more than %d entries without filling the page; use key-based pagination instead", MaxScanLimit)
+		}
+		// Phase 2: page complete — cap how far past the page we scan for nextKey/count_total.
+		if pageCompleteIter > MaxScanLimit {
+			if !countTotal {
+				// Page is already assembled; no next hit found within scan window → no next page.
+				break
+			}
+			return nil, nil, status.Errorf(codes.InvalidArgument,
+				"scanned more than %d entries past the end of the page; use key-based pagination instead", MaxScanLimit)
+		}
+
 		if iterator.Error() != nil {
 			return nil, nil, iterator.Error()
 		}
@@ -232,6 +299,10 @@ func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 				results = append(results, val)
 			}
 			numHits++
+		}
+
+		if numHits >= end {
+			pageCompleteIter++
 		}
 
 		if numHits == end+1 {

--- a/sei-cosmos/types/query/filtered_pagination_test.go
+++ b/sei-cosmos/types/query/filtered_pagination_test.go
@@ -47,7 +47,7 @@ func (s *paginationTestSuite) TestFilteredPaginations() {
 	s.Require().NoError(err)
 	s.Require().NotNil(res)
 	s.Require().Equal(4, len(balances))
-	s.Require().Equal(uint64(4), res.Total)
+	s.Require().Equal(uint64(0), res.Total)
 	s.Require().Nil(res.NextKey)
 
 	s.T().Log("verify nextKey is returned if there are more results")
@@ -79,7 +79,7 @@ func (s *paginationTestSuite) TestFilteredPaginations() {
 	s.Require().NoError(err)
 	s.Require().NotNil(res)
 	s.Require().Equal(4, len(balances))
-	s.Require().Equal(uint64(4), res.Total)
+	s.Require().Equal(uint64(0), res.Total)
 
 	s.T().Log("verify with offset")
 	pageReq = &query.PageRequest{Offset: 2, Limit: 2}
@@ -122,7 +122,7 @@ func (s *paginationTestSuite) TestReverseFilteredPaginations() {
 	s.Require().NoError(err)
 	s.Require().NotNil(res)
 	s.Require().Equal(10, len(balns))
-	s.Require().Equal(uint64(10), res.Total)
+	s.Require().Equal(uint64(0), res.Total)
 	s.Require().Nil(res.NextKey)
 
 	s.T().Log("verify default limit")
@@ -131,7 +131,7 @@ func (s *paginationTestSuite) TestReverseFilteredPaginations() {
 	s.Require().NoError(err)
 	s.Require().NotNil(res)
 	s.Require().Equal(10, len(balns))
-	s.Require().Equal(uint64(10), res.Total)
+	s.Require().Equal(uint64(0), res.Total)
 
 	s.T().Log("verify nextKey is returned if there are more results")
 	pageReq = &query.PageRequest{Limit: 2, CountTotal: true, Reverse: true}
@@ -168,6 +168,110 @@ func (s *paginationTestSuite) TestReverseFilteredPaginations() {
 	s.T().Log("verify Reverse pagination returns valid result")
 	s.Require().Equal(balances[235:241].String(), balns.Sort().String())
 
+}
+
+func (s *paginationTestSuite) TestFilteredPaginateMaxLimitExceeded() {
+	app, ctx, _ := setupTest(s.T())
+	store := ctx.KVStore(app.GetKey(types.StoreKey))
+
+	_, err := query.FilteredPaginate(store, &query.PageRequest{Limit: query.MaxLimit + 1}, func(_ []byte, _ []byte, _ bool) (bool, error) {
+		return false, nil
+	})
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "exceeds maximum allowed limit")
+}
+
+func (s *paginationTestSuite) TestFilteredPaginateOffsetExceedsMax() {
+	app, ctx, _ := setupTest(s.T())
+	kvStore := ctx.KVStore(app.GetKey(types.StoreKey))
+
+	_, err := query.FilteredPaginate(kvStore, &query.PageRequest{Offset: query.MaxOffset + 1}, func(_ []byte, _ []byte, _ bool) (bool, error) {
+		return false, nil
+	})
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "exceeds maximum allowed offset")
+
+	_, err = query.FilteredPaginate(kvStore, &query.PageRequest{Offset: query.MaxOffset}, func(_ []byte, _ []byte, _ bool) (bool, error) {
+		return false, nil
+	})
+	s.Require().NoError(err)
+}
+
+func (s *paginationTestSuite) TestFilteredPaginateCountTotalScanLimitExceeded() {
+	app, ctx, _ := setupTest(s.T())
+	kvStore := prefix.NewStore(ctx.KVStore(app.GetKey(types.StoreKey)), []byte("filteredscanlimit/"))
+
+	numItems := int(query.MaxScanLimit) + 2
+	for i := 0; i < numItems; i++ {
+		kvStore.Set([]byte(fmt.Sprintf("%08d", i)), []byte("v"))
+	}
+
+	_, err := query.FilteredPaginate(kvStore, &query.PageRequest{Limit: 1, CountTotal: true}, func(_ []byte, _ []byte, _ bool) (bool, error) {
+		return true, nil
+	})
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "scanned more than")
+}
+
+func (s *paginationTestSuite) TestFilteredPaginateCountTotalScanLimitExceededNoHits() {
+	app, ctx, _ := setupTest(s.T())
+	kvStore := prefix.NewStore(ctx.KVStore(app.GetKey(types.StoreKey)), []byte("filteredscanlimitnohits/"))
+
+	// Phase 1 fires when totalIter > offset + MaxScanLimit = 10001
+	pageReq := &query.PageRequest{Offset: 1, CountTotal: true}
+	numItems := int(query.MaxScanLimit) + 2
+	for i := 0; i < numItems; i++ {
+		kvStore.Set([]byte(fmt.Sprintf("%08d", i)), []byte("v"))
+	}
+
+	// filter returns no hits — numHits never reaches end, Phase 1 guard must fire
+	_, err := query.FilteredPaginate(kvStore, pageReq, func(_ []byte, _ []byte, _ bool) (bool, error) {
+		return false, nil
+	})
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "scanned more than")
+}
+
+func (s *paginationTestSuite) TestFilteredPaginateSparseFilterFillsPageWithinScanLimit() {
+	app, ctx, _ := setupTest(s.T())
+	kvStore := prefix.NewStore(ctx.KVStore(app.GetKey(types.StoreKey)), []byte("filteredsparse/"))
+
+	numItems := int(query.MaxScanLimit)
+	for i := 0; i < numItems; i++ {
+		value := "miss"
+		if i%1000 == 0 {
+			value = "hit"
+		}
+		kvStore.Set([]byte(fmt.Sprintf("%08d", i)), []byte(value))
+	}
+
+	var hits [][]byte
+	onResult := func(key []byte, value []byte, accumulate bool) (bool, error) {
+		if string(value) != "hit" {
+			return false, nil
+		}
+		if accumulate {
+			hits = append(hits, key)
+		}
+		return true, nil
+	}
+
+	res, err := query.FilteredPaginate(kvStore, &query.PageRequest{Limit: 5}, onResult)
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Require().Equal(5, len(hits))
+	s.Require().Equal("00000000", string(hits[0]))
+	s.Require().Equal("00004000", string(hits[4]))
+	s.Require().Equal("00005000", string(res.NextKey))
+
+	s.T().Log("count_total scans the rest of the store, still within the Phase 2 cap")
+	hits = nil
+	res, err = query.FilteredPaginate(kvStore, &query.PageRequest{Limit: 5, CountTotal: true}, onResult)
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Require().Equal(5, len(hits))
+	s.Require().Equal(uint64(10), res.Total)
+	s.Require().NotNil(res.NextKey)
 }
 
 func execFilterPaginate(store sdk.KVStore, pageReq *query.PageRequest, appCodec codec.Codec) (balances sdk.Coins, res *query.PageResponse, err error) {

--- a/sei-cosmos/types/query/pagination.go
+++ b/sei-cosmos/types/query/pagination.go
@@ -2,7 +2,6 @@ package query
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store/types"
 	db "github.com/tendermint/tm-db"
@@ -14,9 +13,15 @@ import (
 // if the `limit` is not supplied, paginate will use `DefaultLimit`
 const DefaultLimit = 100
 
-// MaxLimit is the maximum limit the paginate function can handle
-// which equals the maximum value that can be stored in uint64
-const MaxLimit = math.MaxUint64
+// MaxLimit is the maximum limit per page the paginate function can handle
+const MaxLimit = uint64(1_000)
+
+// MaxScanLimit is the maximum number of store entries the paginate function
+// will iterate past the page end when count_total is requested.
+const MaxScanLimit = uint64(10_000)
+
+// MaxOffset is the maximum offset allowed in a PageRequest.
+const MaxOffset = uint64(10_000)
 
 // ParsePagination validate PageRequest and returns page number & limit.
 func ParsePagination(pageReq *PageRequest) (page, limit int, err error) {
@@ -30,6 +35,10 @@ func ParsePagination(pageReq *PageRequest) (page, limit int, err error) {
 	if offset < 0 {
 		return 1, 0, status.Error(codes.InvalidArgument, "offset must greater than 0")
 	}
+	// #nosec G115 -- offset is non-negative after validation above; fits in uint64
+	if offsetErr := VerifyPaginationOffset(uint64(offset)); offsetErr != nil {
+		return 1, 0, offsetErr
+	}
 
 	if limit < 0 {
 		return 1, 0, status.Error(codes.InvalidArgument, "limit must greater than 0")
@@ -37,9 +46,28 @@ func ParsePagination(pageReq *PageRequest) (page, limit int, err error) {
 		limit = DefaultLimit
 	}
 
+	// #nosec G115 -- limit is positive after validation above; fits in uint64
+	if limitErr := VerifyPaginationLimit(uint64(limit)); limitErr != nil {
+		return 1, 0, limitErr
+	}
+
 	page = offset/limit + 1
 
 	return page, limit, nil
+}
+
+func VerifyPaginationLimit(limit uint64) error {
+	if limit > MaxLimit {
+		return status.Errorf(codes.InvalidArgument, "limit %d exceeds maximum allowed limit %d", limit, MaxLimit)
+	}
+	return nil
+}
+
+func VerifyPaginationOffset(offset uint64) error {
+	if offset > MaxOffset {
+		return status.Errorf(codes.InvalidArgument, "offset %d exceeds maximum allowed offset %d", offset, MaxOffset)
+	}
+	return nil
 }
 
 // Paginate does pagination of all the results in the PrefixStore based on the
@@ -49,28 +77,26 @@ func Paginate(
 	pageRequest *PageRequest,
 	onResult func(key []byte, value []byte) error,
 ) (*PageResponse, error) {
-
-	// if the PageRequest is nil, use default PageRequest
 	if pageRequest == nil {
 		pageRequest = &PageRequest{}
 	}
-
 	offset := pageRequest.Offset
 	key := pageRequest.Key
 	limit := pageRequest.Limit
-	countTotal := pageRequest.CountTotal
-	reverse := pageRequest.Reverse
-
+	if limit == 0 {
+		limit = DefaultLimit
+	}
 	if offset > 0 && key != nil {
 		return nil, fmt.Errorf("invalid request, either offset or key is expected, got both")
 	}
-
-	if limit == 0 {
-		limit = DefaultLimit
-
-		// count total results when the limit is zero/not supplied
-		countTotal = true
+	if err := VerifyPaginationLimit(limit); err != nil {
+		return nil, err
 	}
+	if err := VerifyPaginationOffset(offset); err != nil {
+		return nil, err
+	}
+	countTotal := pageRequest.CountTotal
+	reverse := pageRequest.Reverse
 
 	if len(key) != 0 {
 		iterator := getIterator(prefixStore, key, reverse)
@@ -80,7 +106,6 @@ func Paginate(
 		var nextKey []byte
 
 		for ; iterator.Valid(); iterator.Next() {
-
 			if count == limit {
 				nextKey = iterator.Key()
 				break
@@ -92,7 +117,6 @@ func Paginate(
 			if err != nil {
 				return nil, err
 			}
-
 			count++
 		}
 
@@ -111,6 +135,11 @@ func Paginate(
 
 	for ; iterator.Valid(); iterator.Next() {
 		count++
+
+		if count > end+MaxScanLimit {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"scanned more than %d entries past the end of the page; use key-based pagination instead", MaxScanLimit)
+		}
 
 		if count <= offset {
 			continue

--- a/sei-cosmos/types/query/pagination_test.go
+++ b/sei-cosmos/types/query/pagination_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/codec"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/crypto/keys/secp256k1"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/store"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/store/prefix"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/types/query"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/bank/types"
@@ -56,6 +57,37 @@ func (s *paginationTestSuite) TestParsePagination() {
 	s.Require().NoError(err)
 	s.Require().Equal(page, 1)
 	s.Require().Equal(limit, 10)
+
+	s.T().Log("verify limit equal to MaxLimit is accepted")
+	pageReq = &query.PageRequest{Limit: query.MaxLimit}
+	_, _, err = query.ParsePagination(pageReq)
+	s.Require().NoError(err)
+
+	s.T().Log("verify limit exceeding MaxLimit is rejected")
+	pageReq = &query.PageRequest{Limit: query.MaxLimit + 1}
+	_, _, err = query.ParsePagination(pageReq)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "exceeds maximum allowed limit")
+
+	s.T().Log("verify offset equal to MaxOffset is accepted")
+	pageReq = &query.PageRequest{Offset: query.MaxOffset, Limit: 1}
+	_, _, err = query.ParsePagination(pageReq)
+	s.Require().NoError(err)
+
+	s.T().Log("verify offset exceeding MaxOffset is rejected")
+	pageReq = &query.PageRequest{Offset: query.MaxOffset + 1, Limit: 1}
+	_, _, err = query.ParsePagination(pageReq)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "exceeds maximum allowed offset")
+}
+
+func (s *paginationTestSuite) TestPaginateMaxLimitExceeded() {
+	app, ctx, _ := setupTest(s.T())
+	store := ctx.KVStore(app.GetKey(types.StoreKey))
+
+	_, err := query.Paginate(store, &query.PageRequest{Limit: query.MaxLimit + 1}, func(_, _ []byte) error { return nil })
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "exceeds maximum allowed limit")
 }
 
 func (s *paginationTestSuite) TestPagination() {
@@ -77,12 +109,12 @@ func (s *paginationTestSuite) TestPagination() {
 	app.AccountKeeper.SetAccount(ctx, acc1)
 	s.Require().NoError(apptesting.FundAccount(app.BankKeeper, ctx, addr1, balances))
 
-	s.T().Log("verify empty page request results a max of defaultLimit records and counts total records")
+	s.T().Log("verify empty page request results a max of defaultLimit records without total count")
 	pageReq := &query.PageRequest{}
 	request := types.NewQueryAllBalancesRequest(addr1, pageReq)
 	res, err := queryClient.AllBalances(gocontext.Background(), request)
 	s.Require().NoError(err)
-	s.Require().Equal(res.Pagination.Total, uint64(numBalances))
+	s.Require().Equal(res.Pagination.Total, uint64(0))
 	s.Require().NotNil(res.Pagination.NextKey)
 	s.Require().LessOrEqual(res.Balances.Len(), defaultLimit)
 
@@ -289,6 +321,35 @@ func (s *paginationTestSuite) TestReversePagination() {
 	s.Require().NoError(err)
 	s.Require().LessOrEqual(res.Balances.Len(), 0)
 	s.Require().Nil(res.Pagination.NextKey)
+}
+
+func (s *paginationTestSuite) TestPaginateOffsetExceedsMax() {
+	app, ctx, _ := setupTest(s.T())
+	kvStore := ctx.KVStore(app.GetKey(types.StoreKey))
+
+	_, err := query.Paginate(kvStore, &query.PageRequest{Offset: query.MaxOffset + 1}, func(_, _ []byte) error { return nil })
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "exceeds maximum allowed offset")
+
+	_, err = query.Paginate(kvStore, &query.PageRequest{Offset: query.MaxOffset}, func(_, _ []byte) error { return nil })
+	s.Require().NoError(err)
+}
+
+func (s *paginationTestSuite) TestPaginateCountTotalScanLimitExceeded() {
+	app, ctx, _ := setupTest(s.T())
+	// Use a dedicated prefix to isolate test data from other store entries.
+	kvStore := prefix.NewStore(ctx.KVStore(app.GetKey(types.StoreKey)), []byte("scanlimit/"))
+
+	// With offset=1, scan cap fires when count > offset+MaxScanLimit = 10,001.
+	// Insert 10,002 items to guarantee the cap is exceeded.
+	numItems := int(query.MaxScanLimit) + 2
+	for i := 0; i < numItems; i++ {
+		kvStore.Set([]byte(fmt.Sprintf("%08d", i)), []byte("v"))
+	}
+
+	_, err := query.Paginate(kvStore, &query.PageRequest{Limit: 1, CountTotal: true}, func(_, _ []byte) error { return nil })
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), fmt.Sprintf("scanned more than %d entries", query.MaxScanLimit))
 }
 
 func setupTest(t *testing.T) (*app.App, sdk.Context, codec.Codec) {

--- a/sei-cosmos/x/auth/tx/service.go
+++ b/sei-cosmos/x/auth/tx/service.go
@@ -192,8 +192,11 @@ func (s txServer) GetBlockWithTxs(ctx context.Context, req *txtypes.GetBlockWith
 	if req.Pagination != nil {
 		offset = req.Pagination.Offset
 		limit = req.Pagination.Limit
-	} else {
-		offset = 0
+		if err = pagination.VerifyPaginationLimit(limit); err != nil {
+			return nil, sdkerrors.ErrInvalidRequest.Wrapf("invalid pagination limit: %d. Max allowed limit is %d", limit, pagination.MaxLimit)
+		}
+	}
+	if limit == 0 {
 		limit = pagination.DefaultLimit
 	}
 

--- a/sei-cosmos/x/bank/keeper/genesis.go
+++ b/sei-cosmos/x/bank/keeper/genesis.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/types/query"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/bank/types"
 )
 
@@ -60,9 +59,9 @@ func (k BaseKeeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 
 // ExportGenesis returns the bank module's genesis state.
 func (k BaseKeeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
-	totalSupply, _, err := k.GetPaginatedTotalSupply(ctx, &query.PageRequest{Limit: query.MaxLimit})
+	totalSupply, err := CollectAllTotalSupply(ctx, k)
 	if err != nil {
-		panic(fmt.Errorf("unable to fetch total supply %v", err))
+		panic(fmt.Errorf("unable to fetch total supply: %w", err))
 	}
 	weiBalances := []types.WeiBalance{}
 	k.IterateAllWeiBalances(ctx, func(aa sdk.AccAddress, i sdk.Int) bool {

--- a/sei-cosmos/x/bank/keeper/invariants.go
+++ b/sei-cosmos/x/bank/keeper/invariants.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
-	"github.com/sei-protocol/sei-chain/sei-cosmos/types/query"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/x/bank/types"
 )
 
@@ -13,8 +12,7 @@ func TotalSupply(k Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
 		expectedTotal := sdk.Coins{}
 		weiTotal := sdk.NewInt(0)
-		supply, _, err := k.GetPaginatedTotalSupply(ctx, &query.PageRequest{Limit: query.MaxLimit})
-
+		supply, err := CollectAllTotalSupply(ctx, k)
 		if err != nil {
 			return sdk.FormatInvariant(types.ModuleName, "query supply",
 				fmt.Sprintf("error querying total supply %v", err)), false

--- a/sei-cosmos/x/bank/keeper/keeper.go
+++ b/sei-cosmos/x/bank/keeper/keeper.go
@@ -106,6 +106,28 @@ func (k BaseKeeper) GetPaginatedTotalSupply(ctx sdk.Context, pagination *query.P
 	return supply, pageRes, nil
 }
 
+// CollectAllTotalSupply returns the full supply by paging with MaxLimit.
+func CollectAllTotalSupply(ctx sdk.Context, k Keeper) (sdk.Coins, error) {
+	totalSupply := sdk.NewCoins()
+	pageReq := &query.PageRequest{Limit: query.MaxLimit}
+
+	for {
+		page, pageRes, err := k.GetPaginatedTotalSupply(ctx, pageReq)
+		if err != nil {
+			return nil, err
+		}
+		totalSupply = totalSupply.Add(page...)
+
+		if pageRes == nil || len(pageRes.NextKey) == 0 {
+			return totalSupply, nil
+		}
+		pageReq = &query.PageRequest{
+			Key:   pageRes.NextKey,
+			Limit: query.MaxLimit,
+		}
+	}
+}
+
 // NewBaseKeeper returns a new BaseKeeper object with a given codec, dedicated
 // store key, an AccountKeeper implementation, and a parameter Subspace used to
 // store and fetch module parameters. The BaseKeeper also accepts a

--- a/sei-cosmos/x/bank/keeper/keeper_test.go
+++ b/sei-cosmos/x/bank/keeper/keeper_test.go
@@ -157,6 +157,12 @@ func (suite *IntegrationTestSuite) TestSendCoinsAndWei() {
 	require.Equal(sdk.NewInt(53), keeper.GetBalance(ctx, addr3, sdk.DefaultBondDenom).Amount)
 }
 
+func (suite *IntegrationTestSuite) TestGetPaginatedTotalSupplyMaxLimitExceeded() {
+	_, _, err := suite.app.BankKeeper.GetPaginatedTotalSupply(suite.ctx, &query.PageRequest{Limit: query.MaxLimit + 1})
+	suite.Require().Error(err)
+	suite.Require().Contains(err.Error(), "exceeds maximum allowed limit")
+}
+
 func (suite *IntegrationTestSuite) TestSupply() {
 	ctx := suite.ctx
 
@@ -185,6 +191,33 @@ func (suite *IntegrationTestSuite) TestSupply() {
 	total, _, err = keeper.GetPaginatedTotalSupply(ctx, &query.PageRequest{})
 	require.NoError(err)
 	require.Equal(total.String(), "")
+}
+
+func (suite *IntegrationTestSuite) TestCollectAllTotalSupplyMultiPage() {
+	ctx := suite.ctx
+	require := suite.Require()
+
+	_, bk := suite.initKeepersWithmAccPerms(make(map[string]bool))
+
+	// 2.5x MaxLimit denoms so CollectAllTotalSupply must merge three pages (two
+	// full, one partial). Distinct amounts per denom so a dropped or duplicated
+	// page boundary changes the result, not just the count.
+	numDenoms := int(query.MaxLimit*2 + query.MaxLimit/2)
+	coins := make(sdk.Coins, numDenoms)
+	for i := 0; i < numDenoms; i++ {
+		coins[i] = sdk.NewInt64Coin(fmt.Sprintf("denom%05d", i), int64(i+1))
+	}
+	totalSupply := coins.Sort()
+	require.NoError(bk.MintCoins(ctx, authtypes.Minter, totalSupply))
+
+	supply, err := keeper.CollectAllTotalSupply(ctx, bk)
+	require.NoError(err)
+	require.Equal(len(totalSupply), len(supply))
+	require.True(totalSupply.IsEqual(supply))
+
+	// the in-consensus TotalSupply invariant consumes the same merged supply
+	msg, broken := keeper.TotalSupply(bk)(ctx)
+	require.False(broken, msg)
 }
 
 func (suite *IntegrationTestSuite) TestIterateSupply() {

--- a/sei-cosmos/x/slashing/client/rest/grpc_query_test.go
+++ b/sei-cosmos/x/slashing/client/rest/grpc_query_test.go
@@ -57,7 +57,7 @@ func (s *IntegrationTestSuite) TestGRPCQueries() {
 	}{
 		{
 			"get signing infos (height specific)",
-			fmt.Sprintf("%s/cosmos/slashing/v1beta1/signing_infos", baseURL),
+			fmt.Sprintf("%s/cosmos/slashing/v1beta1/signing_infos?pagination.count_total=true", baseURL),
 			map[string]string{
 				grpctypes.GRPCBlockHeightHeader: "1",
 			},

--- a/sei-cosmos/x/staking/keeper/grpc_query_test.go
+++ b/sei-cosmos/x/staking/keeper/grpc_query_test.go
@@ -28,7 +28,7 @@ func (suite *KeeperTestSuite) TestGRPCQueryValidators() {
 		{
 			"empty request",
 			func() {
-				req = &types.QueryValidatorsRequest{}
+				req = &types.QueryValidatorsRequest{Pagination: &query.PageRequest{CountTotal: true}}
 			},
 			true,
 
@@ -38,7 +38,7 @@ func (suite *KeeperTestSuite) TestGRPCQueryValidators() {
 		{
 			"empty status returns all the validators",
 			func() {
-				req = &types.QueryValidatorsRequest{Status: ""}
+				req = &types.QueryValidatorsRequest{Status: "", Pagination: &query.PageRequest{CountTotal: true}}
 			},
 			true,
 			len(vals),

--- a/x/evm/types/ethtx/semantic_validation.go
+++ b/x/evm/types/ethtx/semantic_validation.go
@@ -48,6 +48,9 @@ func validateAccessList(accessList AccessList) error {
 }
 
 func validateAuthList(authList AuthList) error {
+	if len(authList) == 0 {
+		return fmt.Errorf("auth list cannot be empty")
+	}
 	for _, auth := range authList {
 		if auth.ChainID == nil {
 			return fmt.Errorf("auth list chain id cannot be nil")

--- a/x/evm/types/ethtx/set_code_tx_test.go
+++ b/x/evm/types/ethtx/set_code_tx_test.go
@@ -1,0 +1,75 @@
+package ethtx
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	"github.com/stretchr/testify/require"
+)
+
+func mockSetCodeTx(authList AuthList) *SetCodeTx {
+	chainID := sdk.NewInt(1)
+	gasTipCap := sdk.NewInt(50)
+	gasFeeCap := sdk.NewInt(100)
+	amount := sdk.NewInt(20)
+	ethAccessList := mockAccessList()
+
+	return &SetCodeTx{
+		ChainID:   &chainID,
+		Nonce:     1,
+		GasTipCap: &gasTipCap,
+		GasFeeCap: &gasFeeCap,
+		GasLimit:  1000,
+		To:        common.Address{'a'}.Hex(),
+		Amount:    &amount,
+		Data:      []byte{'b'},
+		Accesses:  NewAccessList(&ethAccessList),
+		AuthList:  authList,
+		V:         []byte{3},
+		R:         []byte{5},
+		S:         []byte{7},
+	}
+}
+
+func mockAuthList() AuthList {
+	chainID := sdk.NewInt(1)
+	return AuthList{
+		{
+			ChainID: &chainID,
+			Address: common.Address{'c'}.Hex(),
+			Nonce:   1,
+			V:       []byte{0},
+			R:       []byte{5},
+			S:       []byte{7},
+		},
+	}
+}
+
+func TestSetCodeTransaction(t *testing.T) {
+	tx := mockSetCodeTx(mockAuthList())
+	require.NoError(t, tx.Validate())
+	require.Equal(t, uint8(ethtypes.SetCodeTxType), tx.TxType())
+	require.Equal(t, tx, tx.Copy())
+	require.Equal(t, tx.GetAuthList(), ethtypes.NewTx(tx.AsEthereumData()).SetCodeAuthorizations())
+	require.Nil(t, tx.GetBlobFeeCap())
+	require.Nil(t, tx.GetBlobHashes())
+
+	baseFee := big.NewInt(2)
+	require.Equal(t, EffectiveGasPrice(baseFee, tx.GasFeeCap.BigInt(), tx.GasTipCap.BigInt()), tx.EffectiveGasPrice(baseFee))
+	require.Equal(t, fee(EffectiveGasPrice(baseFee, tx.GasFeeCap.BigInt(), tx.GasTipCap.BigInt()), tx.GasLimit), tx.EffectiveFee(baseFee))
+	require.Equal(t, cost(fee(EffectiveGasPrice(baseFee, tx.GasFeeCap.BigInt(), tx.GasTipCap.BigInt()), tx.GasLimit), tx.Amount.BigInt()), tx.EffectiveCost(baseFee))
+}
+
+func TestValidateSetCodeTransactionRejectsEmptyAuthList(t *testing.T) {
+	tx := mockSetCodeTx(nil)
+	require.ErrorContains(t, tx.Validate(), "auth list cannot be empty")
+
+	tx.AuthList = AuthList{}
+	require.ErrorContains(t, tx.Validate(), "auth list cannot be empty")
+
+	tx.AuthList = mockAuthList()
+	require.NoError(t, tx.Validate())
+}


### PR DESCRIPTION
## Overview

This PR introduces several security, stability, and performance improvements across the Sei codebase.

## Key Changes

### Security & DoS Protection
- **Harden paginated RPC queries**: Adds `MaxLimit` (1,000), `MaxOffset` (10,000), and `MaxScanLimit` (10,000) to prevent unbounded store walks
- **Per-IP rate limiting for EVM RPC**: Implements token-bucket rate limiter with configurable RPS/burst limits (`ip_rate_limit_rps`, `ip_rate_limit_burst`)
- **Empty auth list validation**: Rejects `SetCode` transactions with empty authorization lists

### Bug Fixes
- **BlockByNumber trace gas fix**: Pass raw tx bytes to `DeliverTx` so Cosmos transactions charge correct gas
- **Consensus params propagation**: Full consensus params (Synchrony, Timeout) now correctly passed to Tendermint
- **Concurrency fix**: Add read lock to `GetCommitKVStore` to prevent race conditions
- **State sync**: Preserve `node_key.json` across state sync operations

### Infrastructure
- **Go-native integration test runner**: YAML test files now run as standard `go test` subtests
- **CI improvements**: Docker images pushed to GHCR for reliable integration tests
- **GHCR cleanup**: Weekly job prunes old test images

### Observability
- New `rpc_rate_limit_rejected_total` metric for rate limiter monitoring

## Testing
- Added comprehensive unit tests for:
  - Rate limiter (`ratelimiter/registry_test.go`)
  - Pagination limits (`filtered_pagination_test.go`)
  - Consensus params propagation (`consensus_params_test.go`)
  - Empty auth list validation (`evm_checktx_test.go`, `set_code_tx_test.go`)
- Go-native integration tests cover bank, staking, mint, gov, oracle, and more modules

## Migration/Upgrade Notes
- No state-breaking changes
- New config options for `app.toml`:
  ```toml
  ip_rate_limit_rps = 200
  ip_rate_limit_burst = 400